### PR TITLE
Fix #1: Add player visibility mode, defaulting to always on for mobile

### DIFF
--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -9,11 +9,13 @@ export function IconButton({
   onClick,
   tooltip,
   className,
+  disabled,
 }: {
   icon: string;
   onClick: () => void;
   tooltip?: string;
   className?: string;
+  disabled?: boolean;
 }) {
   const ref = React.useRef<HTMLElement | null>(null);
   React.useEffect(() => {
@@ -25,13 +27,15 @@ export function IconButton({
     }
   }, [ref.current, icon, tooltip]);
   return (
-    <div
+    <button
       className={(className ? [className] : [])
         .concat(["clickable-icon tts-toolbar-button"])
         .join(" ")}
       ref={(x) => (ref.current = x)}
-      onClick={onClick}
-    ></div>
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      {...(disabled ? { "aria-disabled": "true" } : {})}
+    ></button>
   );
 }
 

--- a/src/components/PlayerView.tsx
+++ b/src/components/PlayerView.tsx
@@ -24,8 +24,27 @@ export const PlayerView = observer(
     sink: AudioSink;
     obsidian: ObsidianBridge;
   }): React.ReactNode => {
-    const isActive = !!player.activeText && editor === obsidian.activeEditor;
-    if (!isActive) {
+    const hasText = !!player.activeText;
+    const isActiveEditor = editor === obsidian.activeEditor;
+    const isFocusedEditor = obsidian.focusedEditor === editor;
+    let shouldShow: boolean;
+    switch (settings.settings.showPlayerView) {
+      case "always":
+        shouldShow = isFocusedEditor || isActiveEditor;
+        break;
+      case "never":
+        shouldShow = false;
+        break;
+      case "always-mobile":
+        shouldShow = obsidian.isMobile()
+          ? isFocusedEditor || isActiveEditor // same as "always"
+          : isActiveEditor && hasText; // same as "playing"
+        break;
+      case "playing":
+        shouldShow = isActiveEditor && hasText;
+        break;
+    }
+    if (!shouldShow) {
       return null;
     }
     return (
@@ -44,6 +63,7 @@ export const PlayerView = observer(
             icon="skip-back"
             tooltip="Previous"
             onClick={() => player.activeText?.goToPrevious()}
+            disabled={!player.activeText}
           />
 
           {player.activeText?.isPlaying ? (
@@ -59,12 +79,14 @@ export const PlayerView = observer(
               icon="step-forward"
               tooltip="Resume"
               onClick={() => player.activeText?.play()}
+              disabled={!player.activeText}
             />
           )}
           <IconButton
             icon="skip-forward"
             tooltip="Next"
             onClick={() => player.activeText?.goToNext()}
+            disabled={!player.activeText}
           />
           <div
             className={"clickable-icon tts-toolbar-button"}
@@ -83,11 +105,13 @@ export const PlayerView = observer(
           />
         </div>
         <div className="tts-toolbar-player-button-group">
-          <IconButton
-            tooltip="Cancel playback"
-            icon="x"
-            onClick={() => player.closePlayer()}
-          />
+          {player.activeText && (
+            <IconButton
+              tooltip="Cancel playback"
+              icon="x"
+              onClick={() => player.closePlayer()}
+            />
+          )}
         </div>
       </div>
     );

--- a/src/components/TTSPluginSettingsTab.tsx
+++ b/src/components/TTSPluginSettingsTab.tsx
@@ -4,8 +4,11 @@ import * as React from "react";
 import { Root, createRoot } from "react-dom/client";
 import { AudioStore } from "src/player/Player";
 import {
+  PlayerViewMode,
   REAL_OPENAI_API_URL,
   TTSPluginSettingsStore,
+  isPlayerViewMode,
+  playViewModes,
 } from "../player/TTSPluginSettings";
 import { IconButton, IconSpan, Spinner } from "./IconButton";
 
@@ -56,7 +59,7 @@ const TTSSettingsTabComponent: React.FC<{
   const [isActive, setActive] = React.useState(false);
   return (
     <>
-      <h1>Open AI TTS</h1>
+      <h1>OpenAI TTS</h1>
       <APIKeyComponent store={store} />
       <VoiceComponent
         store={store}
@@ -64,6 +67,8 @@ const TTSSettingsTabComponent: React.FC<{
         isActive={isActive}
         setActive={setActive}
       />
+      <h1>User Interface</h1>
+      <PlayerDisplayMode store={store} />
       <h1>Advanced</h1>
       <CacheDuration store={store} player={player} />
       <APIBaseURLComponent store={store} />
@@ -79,6 +84,52 @@ function humanFileSize(size: number) {
     ["B", "kB", "MB", "GB", "TB"][i]
   );
 }
+
+function describeMode(mode: PlayerViewMode): string {
+  switch (mode) {
+    case "always":
+      return "Always show";
+    case "always-mobile":
+      return "Always show on mobile";
+    case "playing":
+      return "Only while playing";
+    case "never":
+      return "Never show";
+  }
+}
+const PlayerDisplayMode: React.FC<{
+  store: TTSPluginSettingsStore;
+}> = observer(({ store }) => {
+  return (
+    <div className="setting-item">
+      <div className="setting-item-info">
+        <div className="setting-item-name">Show player toolbar</div>
+        <div className="setting-item-description">
+          Show the player toolbar under these conditions
+        </div>
+      </div>
+      <div className="setting-item-control">
+        <select
+          value={store.settings.showPlayerView}
+          onChange={(e) => {
+            const value = e.target.value;
+            if (isPlayerViewMode(value)) {
+              store.updateSettings({ showPlayerView: value });
+            } else {
+              console.error("invalid player view mode", value);
+            }
+          }}
+        >
+          {playViewModes.map((mode) => (
+            <option key={mode} value={mode}>
+              {describeMode(mode)}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+});
 
 const CacheDuration: React.FC<{
   store: TTSPluginSettingsStore;
@@ -163,11 +214,11 @@ const APIBaseURLComponent: React.FC<{
   return (
     <div className="setting-item">
       <div className="setting-item-info">
-        <div className="setting-item-name">OpenAI API base URL</div>
+        <div className="setting-item-name">Custom OpenAI URL</div>
         <div className="setting-item-description">
           Change to use a custom OpenAI compatible API server. Default is{" "}
-          {REAL_OPENAI_API_URL}. Note: Token validation will be disabled if this
-          is set
+          {REAL_OPENAI_API_URL}.<br />
+          Note: Token validation will be disabled if this is set
         </div>
       </div>
       <div className="setting-item-control">

--- a/src/player/TTSPluginSettings.ts
+++ b/src/player/TTSPluginSettings.ts
@@ -11,6 +11,20 @@ export interface TTSPluginSettings {
   chunkType: "sentence" | "paragraph";
   playbackSpeed: number;
   cacheDurationMillis: number;
+  showPlayerView: PlayerViewMode;
+}
+
+export const playViewModes = [
+  "always",
+  "always-mobile",
+  "playing",
+  "never",
+] as const;
+
+export type PlayerViewMode = (typeof playViewModes)[number];
+
+export function isPlayerViewMode(value: unknown): value is PlayerViewMode {
+  return playViewModes.includes(value as PlayerViewMode);
 }
 
 export function voiceHash(options: TTSModelOptions): string {
@@ -28,7 +42,8 @@ export const DEFAULT_SETTINGS: TTSPluginSettings = {
   ttsVoice: "shimmer", // alloy, echo, fable, onyx, nova, and shimmer
   chunkType: "sentence",
   playbackSpeed: 1.0,
-  cacheDurationMillis: 1000 * 60 * 60 * 24 * 7,
+  cacheDurationMillis: 1000 * 60 * 60 * 24 * 7, // 7 days
+  showPlayerView: "always-mobile",
 } as const;
 
 /** interface is easier if its just some canned speeds */


### PR DESCRIPTION
Updates player view to support disabled buttons:

<img width="655" alt="image" src="https://github.com/adrianlyjak/obsidian-aloud-tts/assets/2024018/33429ac5-610d-40c0-a3f5-37d0fbfbee95">

Adds visibility options:

<img width="612" alt="image" src="https://github.com/adrianlyjak/obsidian-aloud-tts/assets/2024018/b766ef75-5a8c-47d0-8448-6637ec7730cf">

Change needed to keep track of focused editor within mobx, so added more state to obsidian bridge
