### PR TITLE
Make audio cache layer configurable between local and vault

### DIFF
--- a/src/components/TTSPluginSettingsTab.tsx
+++ b/src/components/TTSPluginSettingsTab.tsx
@@ -145,6 +145,9 @@ const CacheDuration: React.FC<{
     loading: boolean;
     size: number;
   }>({ loading: true, size: 0 });
+  const setLoading = React.useCallback(() => {
+    setCacheSize({ loading: true, size: 0 });
+  }, []);
   React.useEffect(() => {
     if (cacheSize.loading) {
       player
@@ -158,13 +161,51 @@ const CacheDuration: React.FC<{
         });
     }
   }, [cacheSize.loading]);
+
+  const [isConfirming, setIsConfirming] = React.useState(false);
+  const confirmClear = React.useCallback(() => {
+    setIsConfirming(false);
+  }, []);
+  const confirm = React.useCallback(() => {
+    setIsConfirming(true);
+  }, []);
   const clearStorage = React.useCallback(() => {
+    confirmClear();
     player.clearStorage().then(() => {
       setCacheSize({ loading: false, size: 0 });
     });
   }, []);
+
+  const setCacheType: React.ChangeEventHandler<HTMLSelectElement> =
+    React.useCallback((event) => {
+      store.updateSettings({
+        cacheType: event.target.value as "local" | "vault",
+      });
+      setCacheSize({ loading: true, size: 0 });
+    }, []);
   return (
     <>
+      <div className="setting-item">
+        <div className="setting-item-info">
+          <div className="setting-item-name">Cache type</div>
+          <div className="setting-item-description">
+            Local device based cache (recommended), or a vault vased cache that
+            is shared across devices.
+            <br />
+            Device local cache is recommended to avoid sync overhead
+          </div>
+        </div>
+        <div className="setting-item-control">
+          <select
+            className="dropdown"
+            value={store.settings.cacheType}
+            onChange={setCacheType}
+          >
+            <option value="local">Local</option>
+            <option value="vault">Vault</option>
+          </select>
+        </div>
+      </div>
       <div className="setting-item">
         <div className="setting-item-info">
           <div className="setting-item-name">Cache duration</div>
@@ -193,11 +234,30 @@ const CacheDuration: React.FC<{
           </div>
         </div>
         <div className="setting-item-control">
-          <IconButton
-            tooltip="Clear cache"
-            icon="trash"
-            onClick={clearStorage}
-          />
+          {isConfirming ? (
+            <>
+              <button onClick={confirmClear}>Cancel</button>
+              <button
+                style={{ backgroundColor: "var(--background-modifier-error)" }}
+                onClick={clearStorage}
+              >
+                Delete
+              </button>
+            </>
+          ) : (
+            <>
+              <IconButton
+                tooltip="Reload"
+                icon="rotate-cw"
+                onClick={setLoading}
+              />
+              <IconButton
+                tooltip="Clear cache"
+                icon="trash"
+                onClick={confirm}
+              />
+            </>
+          )}
         </div>
       </div>
     </>

--- a/src/obsidian/TTSPlugin.ts
+++ b/src/obsidian/TTSPlugin.ts
@@ -11,7 +11,7 @@ import {
   pluginSettingsStore,
 } from "../player/TTSPluginSettings";
 import { ObsidianBridge, ObsidianBridgeImpl } from "./ObsidianBridge";
-import { IndexedDBAudioStorage } from "../web/IndexedDBAudioStorage";
+import { configurableAudioCache } from "./ObsidianPlayer";
 
 // standard lucide.dev icon, but for some reason not working as a ribbon icon without registering it
 // https://lucide.dev/icons/audio-lines
@@ -26,6 +26,7 @@ export default class TTSPlugin extends Plugin {
   player: AudioStore;
   audio: AudioSink;
   bridge: ObsidianBridge;
+  cache: { destroy: () => void } | undefined;
 
   async onload() {
     await this.loadSettings();
@@ -104,9 +105,11 @@ export default class TTSPlugin extends Plugin {
       (data) => this.saveData(data),
     );
     this.audio = new WebAudioSink();
+    const cache = configurableAudioCache(this.app, this.settings);
+    this.cache = cache;
     this.player = await loadAudioStore({
       settings: this.settings.settings,
-      storage: new IndexedDBAudioStorage(),
+      storage: cache,
       audioSink: this.audio,
     });
     this.bridge = new ObsidianBridgeImpl(this.app, this.player);

--- a/src/player/TTSPluginSettings.ts
+++ b/src/player/TTSPluginSettings.ts
@@ -10,6 +10,7 @@ export interface TTSPluginSettings {
   ttsVoice: string;
   chunkType: "sentence" | "paragraph";
   playbackSpeed: number;
+  cacheType: "local" | "vault";
   cacheDurationMillis: number;
   showPlayerView: PlayerViewMode;
 }
@@ -43,6 +44,7 @@ export const DEFAULT_SETTINGS: TTSPluginSettings = {
   chunkType: "sentence",
   playbackSpeed: 1.0,
   cacheDurationMillis: 1000 * 60 * 60 * 24 * 7, // 7 days
+  cacheType: "local",
   showPlayerView: "always-mobile",
 } as const;
 


### PR DESCRIPTION
Follow on to #22 - Make local / vault based cache configurable

<img width="787" alt="image" src="https://github.com/adrianlyjak/obsidian-aloud-tts/assets/2024018/12e92730-5587-45ce-8132-1b7aa71c1e10">

Add refresh button to show latest size of cache, and add confirmation of data deletion

<img width="761" alt="image" src="https://github.com/adrianlyjak/obsidian-aloud-tts/assets/2024018/4c7566bc-39a0-4b4c-8977-6290abeb5437">
