### PR TITLE
Add custom voice id to eleven labs integration

### DIFF
--- a/src/models/elevenlabs.test.ts
+++ b/src/models/elevenlabs.test.ts
@@ -314,6 +314,29 @@ describe("ElevenLabs Model", () => {
       ]);
     });
 
+    it("should include voice_type query when provided", async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({
+          voices: [],
+        }),
+      };
+
+      vi.mocked(fetch).mockResolvedValue(mockResponse as any);
+
+      await listElevenLabsVoices("test-api-key", "personal");
+
+      expect(fetch).toHaveBeenCalledWith(
+        `${ELEVENLABS_API_URL}/v1/voices?voice_type=personal`,
+        {
+          headers: {
+            "xi-api-key": "test-api-key",
+          },
+        },
+      );
+    });
+
     it("should handle API errors", async () => {
       const mockResponse = {
         ok: false,

--- a/src/models/elevenlabs.ts
+++ b/src/models/elevenlabs.ts
@@ -110,8 +110,13 @@ export async function elevenLabsCallTextToSpeech(
 
 export async function listElevenLabsVoices(
   apiKey: string,
+  voiceType?: "personal" | "community" | "workspace" | "default" | "non-default",
 ): Promise<{ id: string; name: string; category: string }[]> {
-  const response = await fetch(`${ELEVENLABS_API_URL}/v1/voices`, {
+  const url = new URL(`${ELEVENLABS_API_URL}/v1/voices`);
+  if (voiceType) {
+    url.searchParams.set("voice_type", voiceType);
+  }
+  const response = await fetch(url.toString(), {
     headers: {
       "xi-api-key": apiKey,
     },

--- a/src/player/TTSPluginSettings.ts
+++ b/src/player/TTSPluginSettings.ts
@@ -72,6 +72,8 @@ export interface ElevenLabsModelConfig {
   elevenlabs_model: string;
   /** the voice ID to use. Required */
   elevenlabs_voice: string;
+  /** filter voice listing by type */
+  elevenlabs_voiceType?: "personal" | "community" | "workspace" | "default";
   /** voice stability setting (0-1) */
   elevenlabs_stability?: number;
   /** voice similarity boost setting (0-1) */
@@ -152,6 +154,7 @@ export const DEFAULT_SETTINGS: TTSPluginSettings = {
   elevenlabs_apiKey: "",
   elevenlabs_model: "eleven_multilingual_v2",
   elevenlabs_voice: "",
+  elevenlabs_voiceType: "default",
   elevenlabs_stability: 0.5,
   elevenlabs_similarity: 0.75,
   // azure


### PR DESCRIPTION
Add manual Voice ID input to ElevenLabs settings for custom IDs and as a fallback.

---
<a href="https://cursor.com/background-agent?bcId=bc-10b45313-0679-41cd-96c4-07719e092a0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10b45313-0679-41cd-96c4-07719e092a0c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

