### PR TITLE
Add next and previous track commands

### DIFF
--- a/docs/src/content/docs/features/commands.md
+++ b/docs/src/content/docs/features/commands.md
@@ -16,6 +16,8 @@ The following commands are available:
 | `Play selection`          | Starts playback of the currently selected text.                                                         |
 | `Play from clipboard`     | Starts playback of the text currently in your system clipboard.                                         |
 | `Play/pause`              | Toggles playback of the current audio. If nothing is playing, it will try to play the current selection. |
+| `Next track`              | Skips to the next chunk/track of the active audio.                                                      |
+| `Previous track`          | Goes back to the previous chunk/track of the active audio.                                              |
 | `Stop`                    | Halts audio playback completely.                                                                        |
 | `Increase playback speed` | Increases the audio playback speed by 0.1x. Maximum speed is 2.5x.                                      |
 | `Decrease playback speed` | Decreases the audio playback speed by 0.1x. Minimum speed is 0.5x.                                      |

--- a/docs/src/content/docs/features/playback-controls.md
+++ b/docs/src/content/docs/features/playback-controls.md
@@ -32,6 +32,8 @@ In addition to the visual player, you can use the following commands from the Co
 -   `Stop`: Halts playback completely and closes the player.
 -   `Increase playback speed`: Increases the playback rate by 0.1.
 -   `Decrease playback speed`: Decreases the playback rate by 0.1.
+-   `Next track`: Skips to the next chunk/track of the active audio.
+-   `Previous track`: Goes back to the previous chunk/track of the active audio.
 
 ## Visual Feedback
 

--- a/src/obsidian/TTSPlugin.ts
+++ b/src/obsidian/TTSPlugin.ts
@@ -158,6 +158,31 @@ export default class TTSPlugin extends Plugin {
       },
     });
 
+    // track navigation
+    this.addCommand({
+      id: "next-track",
+      name: "Next track",
+      checkCallback: (checking) => {
+        const hasActive = !!this.player.activeText;
+        if (checking) {
+          return hasActive;
+        }
+        this.player.activeText?.goToNext();
+      },
+    });
+
+    this.addCommand({
+      id: "previous-track",
+      name: "Previous track",
+      checkCallback: (checking) => {
+        const hasActive = !!this.player.activeText;
+        if (checking) {
+          return hasActive;
+        }
+        this.player.activeText?.goToPrevious();
+      },
+    });
+
     this.registerEditorExtension(
       TTSCodeMirror(this.player, this.settings, this.audio, this.bridge),
     );


### PR DESCRIPTION
Resolve #91

Add 'Next track' and 'Previous track' command palette commands to allow users to navigate audio chunks.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a782095-4c0b-4b63-aa30-ca8750e54625">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8a782095-4c0b-4b63-aa30-ca8750e54625">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

