### PR TITLE
Add paragraph chunking setting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,15 @@ Effectively, you'll need to move this repository into your `.obsidian/plugins` f
 1. Get the change to the main branch.
 2. Run `./version-bump.sh`. It bumps the current version from package.json, and adds it to other obsidian files and creates a tag and pushes it. See error message for usage. For example, when starting from `0.1.0`, run `./version-bump.sh patch rc` to create a new patch version. This will adjust the version to `0.1.1-rc1`. If that looks good, run `version-bump.sh release` to create a new release from the candidate e.g. `0.1.1`
 3. Wait for github action. Release the Draft in github UI
+
+## Running the web app
+
+This keeps obsidian at arms distance, allowing it to be run also in your browser! (Not firefox right now).
+This makes developing simple features faster and debugging safari web views easier.
+
+To run it:
+
+```sh
+pnpm run web:dev
+```
+It's a bit janky, visit, http://localhost:5173/src/web/ 

--- a/src/components/TTSSettingsTabComponent.tsx
+++ b/src/components/TTSSettingsTabComponent.tsx
@@ -74,6 +74,35 @@ export const TTSSettingsTabComponent: React.FC<{
       <h1>Storage</h1>
       <CacheDuration store={store} player={player} />
       <AudioFolderComponent store={store} />
+      <details style={{ marginTop: "1rem" }}>
+        <summary>
+          <div className="setting-item-name">Advanced</div>
+          <div className="setting-item-description">
+            Less commonly used options
+          </div>
+        </summary>
+        <div className="setting-item">
+          <div className="setting-item-info">
+            <div className="setting-item-name">Text chunking</div>
+            <div className="setting-item-description">
+              Split text into sentences or paragraphs for playback
+            </div>
+          </div>
+          <div className="setting-item-control">
+            <select
+              value={store.settings.chunkType}
+              onChange={(e) =>
+                store.updateSettings({
+                  chunkType: e.target.value as "sentence" | "paragraph",
+                })
+              }
+            >
+              <option value="sentence">Sentence</option>
+              <option value="paragraph">Paragraph</option>
+            </select>
+          </div>
+        </div>
+      </details>
     </>
   );
 });

--- a/src/components/TTSSettingsTabComponent.tsx
+++ b/src/components/TTSSettingsTabComponent.tsx
@@ -74,36 +74,37 @@ export const TTSSettingsTabComponent: React.FC<{
       <h1>Storage</h1>
       <CacheDuration store={store} player={player} />
       <AudioFolderComponent store={store} />
-      <details style={{ marginTop: "1rem" }}>
-        <summary>
-          <div className="setting-item-name">Advanced</div>
-          <div className="setting-item-description">
-            Less commonly used options
-          </div>
-        </summary>
-        <div className="setting-item">
-          <div className="setting-item-info">
-            <div className="setting-item-name">Text chunking</div>
-            <div className="setting-item-description">
-              Split text into sentences or paragraphs for playback
-            </div>
-          </div>
-          <div className="setting-item-control">
-            <select
-              value={store.settings.chunkType}
-              onChange={(e) =>
-                store.updateSettings({
-                  chunkType: e.target.value as "sentence" | "paragraph",
-                })
-              }
-            >
-              <option value="sentence">Sentence</option>
-              <option value="paragraph">Paragraph</option>
-            </select>
-          </div>
-        </div>
-      </details>
+      <h1>Audio</h1>
+      <AudioOptions store={store} />
     </>
+  );
+});
+
+const AudioOptions: React.FC<{
+  store: TTSPluginSettingsStore;
+}> = observer(({ store }) => {
+  return (
+    <div className="setting-item">
+      <div className="setting-item-info">
+        <div className="setting-item-name">Text chunking</div>
+        <div className="setting-item-description">
+          Split text into sentences or paragraphs for playback
+        </div>
+      </div>
+      <div className="setting-item-control">
+        <select
+          value={store.settings.chunkType}
+          onChange={(e) =>
+            store.updateSettings({
+              chunkType: e.target.value as "sentence" | "paragraph",
+            })
+          }
+        >
+          <option value="sentence">Sentence</option>
+          <option value="paragraph">Paragraph</option>
+        </select>
+      </div>
+    </div>
   );
 });
 

--- a/src/components/settings/providers/provider-openai.tsx
+++ b/src/components/settings/providers/provider-openai.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { TTSPluginSettingsStore } from "../../../player/TTSPluginSettings";
 import { ApiKeyComponent } from "../api-key-component";
 import { OptionSelectSetting, TextareaSetting } from "../setting-components";
+import { DEFAULT_OPENAI_MODELS } from "../../../models/openai";
 
 export const OpenAISettings = observer(
   ({ store }: { store: TTSPluginSettingsStore }) => {
@@ -23,21 +24,6 @@ export const OpenAISettings = observer(
     );
   },
 );
-interface OpenAIModel {
-  label: string;
-  value: string;
-  supportsInstructions?: boolean;
-}
-
-const DEFAULT_OPENAI_MODELS: OpenAIModel[] = [
-  {
-    label: "gpt-4o-mini-tts",
-    value: "gpt-4o-mini-tts",
-    supportsInstructions: true,
-  },
-  { label: "tts-1", value: "tts-1" },
-  { label: "tts-1-hd", value: "tts-1-hd" },
-] as const;
 
 const OpenAIModelComponent: React.FC<{
   store: TTSPluginSettingsStore;

--- a/src/player/ActiveAudioText.ts
+++ b/src/player/ActiveAudioText.ts
@@ -154,7 +154,9 @@ export function buildTrack(
 ): AudioText {
   const splits =
     chunkType === "sentence"
-      ? splitSentences(opts.text, { minLength: opts.minChunkLength ?? 20 })
+      ? splitSentences(opts.text, {
+          minLength: opts.minChunkLength ?? 20,
+        })
       : splitParagraphs(opts.text, { maxChunkSize: 1000 });
 
   let start = opts.start;

--- a/src/player/ActiveAudioText.ts
+++ b/src/player/ActiveAudioText.ts
@@ -155,7 +155,7 @@ export function buildTrack(
   const splits =
     chunkType === "sentence"
       ? splitSentences(opts.text, { minLength: opts.minChunkLength ?? 20 })
-      : splitParagraphs(opts.text);
+      : splitParagraphs(opts.text, { maxChunkSize: 1000 });
 
   let start = opts.start;
   const chunks = [];

--- a/src/util/misc.test.ts
+++ b/src/util/misc.test.ts
@@ -84,6 +84,20 @@ describe("misc utilities", () => {
       expect(paragraphs[1]).toContain("Second paragraph");
       expect(paragraphs[2]).toContain("Third paragraph");
     });
+    it("should split really long text", () => {
+      const maxChunkSize = 1000;
+      // 20 characters per sentence, so 2000 chars total. Perfectly splits at the sentence boundary.
+      const sentence = "This is a sentence. ";
+      const text = sentence.repeat(100);
+      const paragraphs = splitParagraphs(text, { maxChunkSize });
+      expect(paragraphs).toHaveLength(2);
+      expect(paragraphs[0]).toContain(
+        "This is a sentence. ".repeat(maxChunkSize / sentence.length),
+      );
+      expect(paragraphs[1]).toContain(
+        "This is a sentence. ".repeat(maxChunkSize / sentence.length),
+      );
+    });
 
     it("should handle single paragraph", () => {
       const text = "Single paragraph with no breaks.";

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -80,12 +80,16 @@ function splitAlongSentenceBoundariesWithMaxLength(
     const chunks = [""];
     for (const sentence of sentences) {
       const currentChunk = chunks[chunks.length - 1];
+      // always append to the current chunk if its empty (even if longer than a chunk!)
+      // this seems better than the alternative of even further splitting.
+      // or if it exceeds the max length (once trimmed)
       if (
         currentChunk &&
         currentChunk.length + sentence.trim().length > maxLength
       ) {
         chunks.push(sentence);
       } else {
+        // otherwise, append the current chunk
         chunks[chunks.length - 1] += sentence;
       }
     }

--- a/src/util/misc.ts
+++ b/src/util/misc.ts
@@ -35,20 +35,61 @@ export function createSlidingWindowGroups(
   return createWindows(sentences, windowSize, stepSize);
 }
 
-export function splitParagraphs(text: string): string[] {
-  return [...genParagraphs(text)];
+export function splitParagraphs(
+  text: string,
+  { maxChunkSize }: { maxChunkSize?: number } = {},
+): string[] {
+  return [...genParagraphs(text, { maxChunkSize })];
 }
-function* genParagraphs(text: string): Iterable<string> {
+function* genParagraphs(
+  text: string,
+  { maxChunkSize = 4000 }: { maxChunkSize?: number } = {},
+): Iterable<string> {
   let lastIndex = 0;
   const splitRegex = /\n\s*\n\s*/g;
   let result: RegExpExecArray | null;
   while ((result = splitRegex.exec(text))) {
     const index = result.index;
-    yield text.substring(lastIndex, index) + result[0];
+    const paragraph = text.substring(lastIndex, index) + result[0];
     lastIndex = index + result[0].length;
+    for (const chunk of splitAlongSentenceBoundariesWithMaxLength(
+      paragraph,
+      maxChunkSize,
+    )) {
+      yield chunk;
+    }
   }
   if (lastIndex < text.length) {
-    yield text.substring(lastIndex);
+    for (const chunk of splitAlongSentenceBoundariesWithMaxLength(
+      text.substring(lastIndex),
+      maxChunkSize,
+    )) {
+      yield chunk;
+    }
+  }
+}
+
+function splitAlongSentenceBoundariesWithMaxLength(
+  text: string,
+  maxLength: number,
+): string[] {
+  if (text.length <= maxLength) {
+    return [text];
+  } else {
+    const sentences = splitSentences(text, { minLength: 20 });
+    const chunks = [""];
+    for (const sentence of sentences) {
+      const currentChunk = chunks[chunks.length - 1];
+      if (
+        currentChunk &&
+        currentChunk.length + sentence.trim().length > maxLength
+      ) {
+        chunks.push(sentence);
+      } else {
+        chunks[chunks.length - 1] += sentence;
+      }
+    }
+    return chunks;
   }
 }
 


### PR DESCRIPTION
Fixes #89 

Add an advanced setting to switch between sentence and paragraph text chunking.

The setting is placed under a collapsible "Advanced" section to keep the main settings UI uncluttered, as requested. The player already supports this `chunkType` setting.

---
<a href="https://cursor.com/background-agent?bcId=bc-13b3a2ba-5ad5-4736-9982-172a88f5aca6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13b3a2ba-5ad5-4736-9982-172a88f5aca6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


