### PR TITLE
Extend markdown regex for highlight cleanup

### DIFF
--- a/src/util/cleanMarkdown.test.ts
+++ b/src/util/cleanMarkdown.test.ts
@@ -52,6 +52,24 @@ describe("cleanMarkdown", () => {
     expect(cleaned).toEqual("be strong");
   });
 
+  it("should remove ==highlight== wrappers (single sentence)", () => {
+    const md = "==This is a sentence==";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual("This is a sentence");
+  });
+
+  it("should remove ==highlight== wrappers (multiple sentences)", () => {
+    const md = "==This is a sentence. This is a sentence.==";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual("This is a sentence. This is a sentence.");
+  });
+
+  it("should remove ==highlight== wrappers embedded in text", () => {
+    const md = "We only ==highlight this phrase== in the sentence.";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual("We only highlight this phrase in the sentence.");
+  });
+
   it("should remove empty code blocks", () => {
     const md = `hello world one
 \`\`\`

--- a/src/util/cleanMarkdown.ts
+++ b/src/util/cleanMarkdown.ts
@@ -41,6 +41,8 @@ export default function cleanMarkup(md: string) {
     //   1. Either there is a whitespace character before opening _ and after closing _.
     //   2. Or _ is at the start/end of the string.
     .replace(/(^|\W)([_]+)(\S)(.*?\S)??\2($|\W)/g, "$1$3$4$5")
+    // Remove == highlight markup (e.g., ==highlight==)
+    .replace(/(==)(\S)(.*?\S)??\1/g, "$2$3")
     // Remove code blocks
     .replace(/^```\w*$\n?/gm, "")
     // Remove inline code


### PR DESCRIPTION
Add regex to `cleanMarkdown` to strip `==highlight==` wrappers, preventing them from being read aloud.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c515674-4c6e-4136-80a3-af60ee10750b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7c515674-4c6e-4136-80a3-af60ee10750b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

