### PR TITLE
Automate version bump and release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,12 @@ on:
   push:
     tags:
       - "*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g., 0.10.1 or 0.10.1-rc1)"
+        required: true
+        type: string
 
 jobs:
   build:
@@ -35,12 +41,16 @@ jobs:
           pnpm run build
 
       - name: Create release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
         run: |
-          tag="${GITHUB_REF#refs/tags/}"
-          
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ github.event.inputs.version }}"
+          else
+            tag="${GITHUB_REF#refs/tags/}"
+          fi
+
           # Check if this is a pre-release version
           if echo "$tag" | grep -qE '-(rc|alpha|beta)'; then
             # Pre-release version

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,23 +1,25 @@
-name: Version bump and tag
+name: Version bump and trigger release
 
 on:
   workflow_dispatch:
     inputs:
       bump:
-        description: "Version bump option (matches ./version-bump.sh usage)"
+        description: "Version bump type"
         type: choice
         required: true
         options:
           - patch
-          - "patch rc"
           - minor
-          - "minor rc"
           - major
-          - "major rc"
           - rc
           - release
           - specified
         default: patch
+      rc:
+        description: "Add rc suffix (only with major/minor/patch)"
+        type: boolean
+        required: false
+        default: false
       version:
         description: "Exact version when bump is 'specified'"
         type: string
@@ -25,6 +27,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   bump:
@@ -57,28 +60,26 @@ jobs:
         env:
           BUMP: ${{ github.event.inputs.bump }}
           SPECIFIED_VERSION: ${{ github.event.inputs.version }}
+          RC: ${{ github.event.inputs.rc }}
         run: |
           set -euo pipefail
-
           case "$BUMP" in
-            "specified")
+            major|minor|patch)
+              if [ "$RC" = "true" ]; then
+                bash ./version-bump.sh "$BUMP" rc
+              else
+                bash ./version-bump.sh "$BUMP"
+              fi
+              ;;
+            rc|release)
+              bash ./version-bump.sh "$BUMP"
+              ;;
+            specified)
               if [ -z "${SPECIFIED_VERSION}" ]; then
                 echo "Error: version input is required when bump='specified'" >&2
                 exit 1
               fi
               bash ./version-bump.sh specified "${SPECIFIED_VERSION}"
-              ;;
-            "rc"|"release"|"major"|"minor"|"patch")
-              bash ./version-bump.sh "$BUMP"
-              ;;
-            "major rc")
-              bash ./version-bump.sh major rc
-              ;;
-            "minor rc")
-              bash ./version-bump.sh minor rc
-              ;;
-            "patch rc")
-              bash ./version-bump.sh patch rc
               ;;
             *)
               echo "Unknown bump option: $BUMP" >&2
@@ -86,5 +87,19 @@ jobs:
               ;;
           esac
 
-      - name: Output new version
-        run: echo "New version: $(jq -r .version package.json)"
+      - name: Extract new version
+        run: |
+          echo "VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
+          echo "New version: $(jq -r .version package.json)"
+
+      - name: Trigger release workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release.yml',
+              ref: process.env.VERSION,
+              inputs: { version: process.env.VERSION }
+            });


### PR DESCRIPTION
Add a GitHub Actions workflow with a dropdown to manually bump the project version, commit, tag, and trigger the release pipeline.

---
<a href="https://cursor.com/background-agent?bcId=bc-46d1edb3-eb67-46a2-9289-f9bef0f56b1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-46d1edb3-eb67-46a2-9289-f9bef0f56b1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

