### PR TITLE
Fix multi-sentence highlight bug

### DIFF
--- a/src/util/cleanMarkdown.test.ts
+++ b/src/util/cleanMarkdown.test.ts
@@ -64,6 +64,24 @@ describe("cleanMarkdown", () => {
     expect(cleaned).toEqual("This is a sentence. This is a sentence.");
   });
 
+  it("should remove ==highlight== when content has trailing space before close", () => {
+    const md = "==This is a sentence. This is a sentence. ==";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual("This is a sentence. This is a sentence.");
+  });
+
+  it("should remove ==highlight== when content has leading spaces after open", () => {
+    const md = "==   This is a sentence. This is a sentence.==";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual("This is a sentence. This is a sentence.");
+  });
+
+  it("should remove ==highlight== wrappers spanning newlines", () => {
+    const md = "==This is a sentence.\nThis is a sentence.==";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual("This is a sentence.\nThis is a sentence.");
+  });
+
   it("should remove ==highlight== wrappers embedded in text", () => {
     const md = "We only ==highlight this phrase== in the sentence.";
     const cleaned = cleanMarkup(md);

--- a/src/util/cleanMarkdown.ts
+++ b/src/util/cleanMarkdown.ts
@@ -41,8 +41,9 @@ export default function cleanMarkup(md: string) {
     //   1. Either there is a whitespace character before opening _ and after closing _.
     //   2. Or _ is at the start/end of the string.
     .replace(/(^|\W)([_]+)(\S)(.*?\S)??\2($|\W)/g, "$1$3$4$5")
-    // Remove == highlight markup (e.g., ==highlight==)
-    .replace(/(==)(\S)(.*?\S)??\1/g, "$2$3")
+    // Remove == highlight markup (e.g., ==highlight==), tolerating inner spaces/newlines
+    // Allows leading/trailing whitespace inside the markers while preserving inner content
+    .replace(/==\s*([\s\S]*?\S)\s*==/g, "$1")
     // Remove code blocks
     .replace(/^```\w*$\n?/gm, "")
     // Remove inline code


### PR DESCRIPTION
Update `cleanMarkup` regex to correctly remove `==highlight==` markup across multiple sentences, including those with internal spaces or newlines.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f372457-c6db-44be-855a-c00793fed062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2f372457-c6db-44be-855a-c00793fed062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

