### PR TITLE
Fix protected branch push error

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -28,6 +28,7 @@ on:
 permissions:
   contents: write
   actions: write
+  pull-requests: write
 
 jobs:
   bump:
@@ -92,14 +93,17 @@ jobs:
           echo "VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
           echo "New version: $(jq -r .version package.json)"
 
-      - name: Trigger release workflow
-        uses: actions/github-script@v7
+      - name: Create pull request for version bump
+        uses: peter-evans/create-pull-request@v6
         with:
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'release.yml',
-              ref: process.env.VERSION,
-              inputs: { version: process.env.VERSION }
-            });
+          commit-message: "chore: bump version to ${{ env.VERSION }}"
+          title: "chore: bump version to ${{ env.VERSION }}"
+          body: |
+            Automated version bump to `${{ env.VERSION }}`.
+
+            - This PR was created because `main` is protected.
+            - Merge this PR to apply the version change.
+            - After merge, create a tag `${{ env.VERSION }}` and run the "Release Obsidian plugin" workflow if desired.
+          branch: chore/version-bump/${{ env.VERSION }}
+          delete-branch: true
+          base: main

--- a/version-bump.sh
+++ b/version-bump.sh
@@ -16,9 +16,17 @@ commands
 fi
 
 node version-bump.mjs $1 $2
+
+# In CI (GitHub Actions), do not create commits/tags or push directly.
+# Leave changes uncommitted so the workflow can open a PR with them.
+if [ "${GITHUB_ACTIONS:-}" = "true" ] || [ "${CI:-}" = "true" ]; then
+  echo "CI detected; skipping git commit, tag, and push. A PR will be created by the workflow."
+  exit 0
+fi
+
 git add manifest.json versions.json package.json
-VERSION="$(cat package.json | jq .version -r)"
+VERSION="$(jq -r .version package.json)"
 git commit -m "update version to $VERSION"
-git tag -a $VERSION -m "Version $VERSION"
+git tag -a "$VERSION" -m "Version $VERSION"
 git push
-git push origin $VERSION
+git push origin "$VERSION"


### PR DESCRIPTION
Update version bump workflow to create a pull request instead of pushing directly to `main` because `main` is a protected branch.

The previous setup for the version bump GitHub Action attempted to directly push changes to the `main` branch. This failed due to `main` being a protected branch, which requires changes to be made via a pull request. This PR modifies the workflow to use `peter-evans/create-pull-request` to open a PR with the version bump changes, and updates the `version-bump.sh` script to skip direct git operations when running in a CI environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2c37ba3-ec0d-4e52-92c9-d93556371413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d2c37ba3-ec0d-4e52-92c9-d93556371413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

