### PR TITLE
fix(minimax): Improve minimax error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Just add your API key from a supported provider. Choose from available voices.
 *   **Hume AI:** (Hume voices with customization)
 *   **ElevenLabs:** (Model selection, voice selection, stability/similarity options)
 *   **Azure Speech Services:** (Region, voice and output format selection)
-*   **MiniMax:** (speech-2.5-hd-preview, speech-2.5-turbo-preview, speech-02-hd, speech-02-turbo, speech-01-hd, speech-01-turbo)
+*   **MiniMax:** (speech-2.6-hd, speech-2.6-turbo, speech-02-hd, speech-02-turbo, speech-01-hd, speech-01-turbo)
 *   **AWS Polly:** (Region, voice, neural/standard engine, output format)
 
 You can also configure a custom API endpoint if you have an OpenAI compatible API server that has an `/v1/audio/speech` endpoint. For example [openedai-speech](https://github.com/matatonic/openedai-speech).

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -74,7 +74,7 @@ For users who self-host a TTS service or use a third-party provider with an Open
 
 -   **API Key**: Your API key from `https://www.minimax.ai/`.
 -   **GroupId**: Your MiniMax GroupId. This is required and is appended to requests as a `?GroupId=` query parameter.
--   **Model**: One of: `speech-2.5-hd-preview`, `speech-2.5-turbo-preview`, `speech-02-hd`, `speech-02-turbo`, `speech-01-hd`, `speech-01-turbo`.
+-   **Model**: One of: `speech-2.6-hd`, `speech-2.6-turbo`, `speech-02-hd`, `speech-02-turbo`, `speech-01-hd`, `speech-01-turbo`.
 -   **Voice**: A supported voice id
 
 Notes:

--- a/src/components/settings/providers/provider-minimax.tsx
+++ b/src/components/settings/providers/provider-minimax.tsx
@@ -14,7 +14,7 @@ export const MinimaxSettings = observer(
           provider="minimax"
           fieldName="minimax_apiKey"
           displayName="MiniMax API key"
-          helpUrl="https://www.minimax.ai/"
+          helpUrl="https://platform.minimax.io/user-center/basic-information/interface-key"
           showValidation={true}
         />
         <TextInputSetting
@@ -23,7 +23,7 @@ export const MinimaxSettings = observer(
           store={store}
           provider="minimax"
           fieldName="minimax_groupId"
-          placeholder="e.g. g-xxxxxxxx"
+          placeholder="e.g. 1234567890"
         />
         <MinimaxModelComponent store={store} />
         <MinimaxVoiceComponent store={store} />
@@ -33,8 +33,8 @@ export const MinimaxSettings = observer(
 );
 
 const MINIMAX_MODELS = [
-  { label: "speech-2.5-hd-preview", value: "speech-2.5-hd-preview" },
-  { label: "speech-2.5-turbo-preview", value: "speech-2.5-turbo-preview" },
+  { label: "speech-2.6-hd", value: "speech-2.6-hd" },
+  { label: "speech-2.6-turbo", value: "speech-2.6-turbo" },
   { label: "speech-02-hd", value: "speech-02-hd" },
   { label: "speech-02-turbo", value: "speech-02-turbo" },
   { label: "speech-01-hd", value: "speech-01-hd" },

--- a/src/player/TTSPluginSettings.ts
+++ b/src/player/TTSPluginSettings.ts
@@ -193,7 +193,7 @@ export const DEFAULT_SETTINGS: TTSPluginSettings = {
   // minimax
   minimax_apiKey: "",
   minimax_groupId: "",
-  minimax_ttsModel: "speech-2.5-turbo-preview",
+  minimax_ttsModel: "speech-2.6-turbo",
   minimax_ttsVoice: "English_expressive_narrator",
 
   // polly

--- a/styles.css
+++ b/styles.css
@@ -140,6 +140,10 @@
   flex: 1 1 auto;
 }
 
+.tts-settings-error-container {
+  display: flex;
+}
+
 .tts-settings-error-container details {
   padding: 0.25rem 0.5rem;
   border-radius: var(--radius-s);


### PR DESCRIPTION
Improve error details for #111, and other minor improvements to minimax integration (better link)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens MiniMax TTS integration and updates model options.
> 
> - Adds `parseMinimaxResponse` to handle Minimax’s 200-OK error bodies; switches to `response.text()` parsing and throws `TTSErrorInfo` with clearer messages; removes `validate200` usage
> - Expands unit tests for success/error paths (API errors with 200, HTTP errors, invalid JSON, missing audio) and updates mocks accordingly
> - Updates MiniMax models from 2.5-preview to 2.6 (`speech-2.6-hd`, `speech-2.6-turbo`) across settings, defaults, README, and docs
> - Improves settings UI: corrected MiniMax API key help URL and GroupId placeholder; minor CSS tweak for error container layout
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab744ecbb5fe3c2df47d146c6bd57d827bbde796. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->