### PR TITLE
fix(inworld): minor clean up from recent inworld addition

### DIFF
--- a/src/components/settings/providers/provider-inworld.tsx
+++ b/src/components/settings/providers/provider-inworld.tsx
@@ -86,7 +86,7 @@ const InworldVoiceComponent: React.FC<{
   }, [apiKey, store.settings]); // Depend on settings object for latest config
 
   const voiceOptions = voices.map((voice) => ({
-    label: `${voice.displayName} (${voice.tags?.join(", ") || voice.voiceId})`,
+    label: `${voice.displayName}`,
     value: voice.voiceId,
   }));
 

--- a/src/models/inworld.ts
+++ b/src/models/inworld.ts
@@ -1,3 +1,4 @@
+import { base64ToArrayBuffer } from "../util/misc";
 import { TTSPluginSettings } from "../player/TTSPluginSettings";
 import {
   AudioTextContext,
@@ -77,12 +78,7 @@ export async function inworldCallTextToSpeech(
   }
 
   // Convert base64 to ArrayBuffer
-  const binaryString = window.atob(json.audioContent);
-  const bytes = new Uint8Array(binaryString.length);
-  for (let i = 0; i < binaryString.length; i++) {
-    bytes[i] = binaryString.charCodeAt(i);
-  }
-  return bytes.buffer;
+  return base64ToArrayBuffer(json.audioContent);
 }
 
 export interface InworldVoice {

--- a/src/util/cleanMarkdown.test.ts
+++ b/src/util/cleanMarkdown.test.ts
@@ -18,7 +18,7 @@ describe("cleanMarkdown", () => {
       "We had fun on our vacation\n\n![fun vacation](https://example.com/path.png)\n\nthere were dolphins";
     const cleaned = cleanMarkup(md);
     expect(cleaned).toEqual(
-      "We had fun on our vacation\n\n\n\nthere were dolphins",
+      "We had fun on our vacation\n\nthere were dolphins",
     );
   });
 
@@ -26,7 +26,7 @@ describe("cleanMarkdown", () => {
     const md =
       "Start ![_page_2_Figure_1.jpeg](Basic%20Airway__page_2_Figure_1.jpeg) End";
     const cleaned = cleanMarkup(md);
-    expect(cleaned).toEqual("Start  End");
+    expect(cleaned).toEqual("Start End");
   });
 
   it("should remove heading tags", () => {
@@ -143,7 +143,7 @@ This is the real content.`;
   it("should remove obsidian image links", () => {
     const md = "Here is an image ![image name](path/to/image.png) in text";
     const cleaned = cleanMarkup(md);
-    expect(cleaned).toEqual("Here is an image  in text");
+    expect(cleaned).toEqual("Here is an image in text");
   });
 
   it("should remove obsidian wiki links", () => {

--- a/src/util/cleanMarkdown.ts
+++ b/src/util/cleanMarkdown.ts
@@ -22,7 +22,7 @@ export default function cleanMarkup(md: string) {
     .replace(/\[\^.+?\](: .*?$)?/g, "")
     .replace(/\s{0,2}\[.*?\]: .*?$/g, "")
     // Remove images
-    .replace(/!\[(.*?)\][[(].*?[\])]/g, "")
+    .replace(/!\[(.*?)\][[(].*?[\])]\s*/g, "")
     // Remove inline links
     .replace(/\[([^\]]*?)\][[(].*?[\])]/g, "$1")
     // remove obsidian links


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Markdown cleanup:** Update `cleanMarkdown` image regex to remove trailing whitespace/newlines after `![alt](src)`; adjust related tests to reflect tighter output.
> - **Inworld TTS:** Replace manual base64 decoding with `base64ToArrayBuffer` in `inworld.ts`.
> - **UI tweak:** Simplify Inworld voice dropdown labels to just `displayName` in `provider-inworld.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b366e45988158792be6bdf4699420a4bb469399f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->