### PR TITLE
Default openai-like response format to mp3

### DIFF
--- a/src/models/openai.test.ts
+++ b/src/models/openai.test.ts
@@ -56,6 +56,7 @@ describe("OpenAI Model API", () => {
           voice: "alloy",
           input: "Hello world",
           speed: 1.0,
+          response_format: "mp3",
         }),
       });
 

--- a/src/models/openai.ts
+++ b/src/models/openai.ts
@@ -79,6 +79,7 @@ export async function openAICallTextToSpeech(
         ...(instructions ? { instructions } : {}),
         input: text,
         speed: 1.0,
+        response_format: "mp3",
       }),
     },
   );


### PR DESCRIPTION
fix #113

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Behavior change**
> 
> - Add `response_format: "mp3"` to `openAICallTextToSpeech` request payload to default audio output format to MP3.
> - Update `openai.test.ts` to expect the new `response_format` field in the TTS request.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a9dcda6788b8042ab886b6678b4995708f56627. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->