### PR TITLE
Release workflow grep fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           fi
 
           # Check if this is a pre-release version
-          if echo "$tag" | grep -qE '-(rc|alpha|beta)'; then
+          if echo "$tag" | grep -qE -- '-(rc|alpha|beta)'; then
             # Pre-release version
             gh release create "$tag" \
               --title="$tag" \


### PR DESCRIPTION
Fix `grep` error in release workflow by adding `--` to the `grep -qE` command.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ac920e2-272d-4f3f-afa9-1361be32bd35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3ac920e2-272d-4f3f-afa9-1361be32bd35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix release workflow prerelease check**
> 
> - Update `release.yml` to use `grep -qE -- '-(rc|alpha|beta)'`, preventing option parsing issues for tags and ensuring correct prerelease detection when creating GitHub releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84113b209cc99e2585b1643f1cfc9fa316ce2e41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->