### PR TITLE
Release notes generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,33 @@
+# Configuration for automatically generated release notes
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - dependencies
+  categories:
+    - title: 🚀 New Features
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: 📚 Documentation
+      labels:
+        - documentation
+        - docs
+    - title: 🧪 Testing
+      labels:
+        - testing
+        - test
+    - title: 🔧 Maintenance
+      labels:
+        - chore
+        - maintenance
+        - refactor
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,12 @@ jobs:
             gh release create "$tag" \
               --title="$tag" \
               --prerelease \
+              --generate-notes \
               main.js manifest.json styles.css
           else
             # Full release version
             gh release create "$tag" \
               --title="$tag" \
+              --generate-notes \
               main.js manifest.json styles.css
           fi


### PR DESCRIPTION
Enable automatic release notes generation using GitHub's built-in functionality to simplify release note creation and categorize PRs by labels.

The `.github/release.yml` file configures how GitHub's automatic release notes are structured, grouping PRs into categories like "New Features", "Bug Fixes", etc., based on their labels. This also automatically includes contributor mentions, fulfilling the request to easily include contribution tags. This approach leverages native GitHub features, avoiding external actions for simplicity.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe80ab9c-e414-45af-bda1-7fb875b02552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe80ab9c-e414-45af-bda1-7fb875b02552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

