### PR TITLE
Minimax china endpoint support

### DIFF
--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -72,15 +72,18 @@ For users who self-host a TTS service or use a third-party provider with an Open
 
 ### MiniMax
 
--   **API Key**: Your API key from `https://www.minimax.ai/`.
+-   **Use China Mainland Endpoint**: Toggle this if you have an API key from the China mainland platform ([platform.minimaxi.com](https://platform.minimaxi.com)). Leave disabled for the international platform ([platform.minimax.io](https://platform.minimax.io)). API keys from one platform are not compatible with the other.
+-   **API Key**: Your API key from MiniMax.
 -   **GroupId**: Your MiniMax GroupId. This is required and is appended to requests as a `?GroupId=` query parameter.
 -   **Model**: One of: `speech-2.6-hd`, `speech-2.6-turbo`, `speech-02-hd`, `speech-02-turbo`, `speech-01-hd`, `speech-01-turbo`.
 -   **Voice**: A supported voice id
 
 Notes:
+-   MiniMax operates two separate platforms with incompatible API keys:
+    -   **International** (default): [platform.minimax.io](https://platform.minimax.io) — higher minimum recharge (~$25)
+    -   **China Mainland**: [platform.minimaxi.com](https://platform.minimaxi.com) — lower entry cost
 -   MiniMax integration currently uses non-streaming synthesis and returns `mp3` decoded from `hex`.
 -   Advanced options like `language_boost`, `timbre_weights`, or streaming are not yet exposed in settings.
--   **Output Format**: Select the desired audio format (e.g., MP3/WAV variants).
 
 ### AWS Polly
 

--- a/src/components/settings/providers/provider-minimax.tsx
+++ b/src/components/settings/providers/provider-minimax.tsx
@@ -2,19 +2,56 @@ import { observer } from "mobx-react-lite";
 import React from "react";
 import { TTSPluginSettingsStore } from "../../../player/TTSPluginSettings";
 import { ApiKeyComponent } from "../api-key-component";
-import { OptionSelectSetting, TextInputSetting } from "../setting-components";
+import {
+  CheckboxSetting,
+  OptionSelectSetting,
+  TextInputSetting,
+} from "../setting-components";
 import { MINIMAX_VOICES } from "./provider-minimax-voices";
 
 export const MinimaxSettings = observer(
   ({ store }: { store: TTSPluginSettingsStore }) => {
+    const useChinaEndpoint = store.settings.minimax_useChinaEndpoint;
+    const helpUrl = useChinaEndpoint
+      ? "https://platform.minimaxi.com/user-center/basic-information/interface-key"
+      : "https://platform.minimax.io/user-center/basic-information/interface-key";
+
     return (
       <>
+        <CheckboxSetting
+          name="Use China Mainland Endpoint"
+          description={
+            <>
+              Enable this if you have an API key from the China mainland
+              platform (
+              <a
+                href="https://platform.minimaxi.com"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                platform.minimaxi.com
+              </a>
+              ). Leave disabled for the international platform (
+              <a
+                href="https://platform.minimax.io"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                platform.minimax.io
+              </a>
+              ). API keys from one platform are not compatible with the other.
+            </>
+          }
+          store={store}
+          provider="minimax"
+          fieldName="minimax_useChinaEndpoint"
+        />
         <ApiKeyComponent
           store={store}
           provider="minimax"
           fieldName="minimax_apiKey"
           displayName="MiniMax API key"
-          helpUrl="https://platform.minimax.io/user-center/basic-information/interface-key"
+          helpUrl={helpUrl}
           showValidation={true}
         />
         <TextInputSetting

--- a/src/models/minimax.ts
+++ b/src/models/minimax.ts
@@ -9,7 +9,17 @@ import {
 import { hexToArrayBuffer } from "../util/misc";
 import { AudioData } from "./tts-model";
 
+/** International endpoint (platform.minimax.io) */
 export const MINIMAX_API_URL = "https://api.minimax.io";
+/** China mainland endpoint (platform.minimaxi.com) */
+export const MINIMAX_CHINA_API_URL = "https://api.minimaxi.com";
+
+/** Get the appropriate Minimax API URL based on settings */
+export function getMinimaxApiUrl(settings: TTSPluginSettings): string {
+  return settings.minimax_useChinaEndpoint
+    ? MINIMAX_CHINA_API_URL
+    : MINIMAX_API_URL;
+}
 
 /** Shape of a successful Minimax TTS response */
 export interface MinimaxTTSResponse {
@@ -115,7 +125,8 @@ export async function minimaxCallTextToSpeech(
   _context: AudioTextContext = {},
 ): Promise<AudioData> {
   const groupId = settings.minimax_groupId;
-  const url = `${MINIMAX_API_URL}/v1/t2a_v2?GroupId=${encodeURIComponent(groupId)}`;
+  const apiUrl = getMinimaxApiUrl(settings);
+  const url = `${apiUrl}/v1/t2a_v2?GroupId=${encodeURIComponent(groupId)}`;
 
   const response = await fetch(url, {
     method: "POST",

--- a/src/player/TTSPluginSettings.ts
+++ b/src/player/TTSPluginSettings.ts
@@ -116,6 +116,8 @@ export interface MinimaxModelConfig {
   minimax_ttsModel: string;
   /** the voice id to use */
   minimax_ttsVoice: string;
+  /** whether to use the China mainland endpoint (api.minimaxi.com) instead of international (api.minimax.io) */
+  minimax_useChinaEndpoint: boolean;
 }
 
 export interface PollyModelConfig {
@@ -212,6 +214,7 @@ export const DEFAULT_SETTINGS: TTSPluginSettings = {
   minimax_groupId: "",
   minimax_ttsModel: "speech-2.6-turbo",
   minimax_ttsVoice: "English_expressive_narrator",
+  minimax_useChinaEndpoint: false,
 
   // inworld
   inworld_apiKey: "",


### PR DESCRIPTION
Adds an option to use the MiniMax China mainland API endpoint to support users with incompatible API keys from that region.

Users with API keys purchased on platform.minimaxi.com (China mainland) were encountering "invalid API key" errors when trying to use the plugin, as these keys are not compatible with the default international endpoint (platform.minimax.io). This change allows them to select the correct regional endpoint.

---
<a href="https://cursor.com/background-agent?bcId=bc-10ca71bd-6b04-40db-8d92-f17bb74fa6c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-10ca71bd-6b04-40db-8d92-f17bb74fa6c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

