### PR TITLE
Fix settings layout for 1.11

### DIFF
--- a/src/components/TTSPluginSettingsTab.test.tsx
+++ b/src/components/TTSPluginSettingsTab.test.tsx
@@ -48,10 +48,8 @@ describe("TTSPluginSettingsTab", () => {
       />,
     );
 
-    // Should render main elements
-    expect(screen.getByText("Aloud")).toBeDefined();
     expect(screen.getByText("Model Provider")).toBeDefined();
-    expect(screen.getByRole("button", { name: /test voice/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /play/i })).toBeDefined();
 
     // Switch through all providers to maximize coverage
     const select = screen.getByDisplayValue("OpenAI");

--- a/src/components/TTSSettingsTabComponent.tsx
+++ b/src/components/TTSSettingsTabComponent.tsx
@@ -2,7 +2,6 @@ import { observer } from "mobx-react-lite";
 import * as React from "react";
 import { AudioStore } from "../player/AudioStore";
 import {
-  MARKETING_NAME,
   ModelProvider,
   PlayerViewMode,
   TTSPluginSettingsStore,
@@ -14,6 +13,7 @@ import { IconButton, Spinner } from "./IconButton";
 import { Play, Pause } from "lucide-react";
 import { TTSErrorInfoDetails, TTSErrorInfoView } from "./PlayerView";
 import { OptionSelect } from "./settings/option-select";
+import { SettingSection } from "./settings/setting-components";
 import { AzureSettings } from "./settings/providers/provider-azure";
 import { ElevenLabsSettings } from "./settings/providers/provider-elevenlabs";
 import { GeminiSettings } from "./settings/providers/provider-gemini";
@@ -31,63 +31,61 @@ export const TTSSettingsTabComponent: React.FC<{
   const [isActive, setActive] = React.useState(false);
   return (
     <>
-      <h1>{MARKETING_NAME}</h1>
       <ErrorInfoView player={player} />
-      <TestVoiceComponent
-        store={store}
-        player={player}
-        isActive={isActive}
-        setActive={setActive}
-      />
-      <div
-        style={{
-          display: "flex",
-          width: "100%",
-          justifyContent: "space-between",
-          alignItems: "center",
-        }}
+      <SettingSection>
+        <TestVoiceComponent
+          store={store}
+          player={player}
+          isActive={isActive}
+          setActive={setActive}
+        />
+      </SettingSection>
+
+      <SettingSection
+        title="Model Provider"
+        control={<ModelSwitcher store={store} />}
       >
-        <h1 style={{ display: "inline-block" }}>Model Provider</h1>
-        <div style={{ display: "inline-block" }}>
-          <ModelSwitcher store={store} />
-        </div>
-      </div>
+        {store.settings.modelProvider === "gemini" && (
+          <GeminiSettings store={store} />
+        )}
+        {store.settings.modelProvider === "hume" && (
+          <HumeSettings store={store} />
+        )}
+        {store.settings.modelProvider === "openai" && (
+          <OpenAISettings store={store} />
+        )}
+        {store.settings.modelProvider === "openaicompat" && (
+          <OpenAICompatibleSettings store={store} />
+        )}
+        {store.settings.modelProvider === "elevenlabs" && (
+          <ElevenLabsSettings store={store} />
+        )}
+        {store.settings.modelProvider === "azure" && (
+          <AzureSettings store={store} />
+        )}
+        {store.settings.modelProvider === "minimax" && (
+          <MinimaxSettings store={store} />
+        )}
+        {store.settings.modelProvider === "inworld" && (
+          <InworldSettings store={store} />
+        )}
+        {store.settings.modelProvider === "polly" && (
+          <PollySettings store={store} />
+        )}
+      </SettingSection>
 
-      {store.settings.modelProvider === "gemini" && (
-        <GeminiSettings store={store} />
-      )}
-      {store.settings.modelProvider === "hume" && (
-        <HumeSettings store={store} />
-      )}
-      {store.settings.modelProvider === "openai" && (
-        <OpenAISettings store={store} />
-      )}
-      {store.settings.modelProvider === "openaicompat" && (
-        <OpenAICompatibleSettings store={store} />
-      )}
-      {store.settings.modelProvider === "elevenlabs" && (
-        <ElevenLabsSettings store={store} />
-      )}
-      {store.settings.modelProvider === "azure" && (
-        <AzureSettings store={store} />
-      )}
-      {store.settings.modelProvider === "minimax" && (
-        <MinimaxSettings store={store} />
-      )}
-      {store.settings.modelProvider === "inworld" && (
-        <InworldSettings store={store} />
-      )}
-      {store.settings.modelProvider === "polly" && (
-        <PollySettings store={store} />
-      )}
+      <SettingSection title="User Interface">
+        <PlayerDisplayMode store={store} />
+      </SettingSection>
 
-      <h1>User Interface</h1>
-      <PlayerDisplayMode store={store} />
-      <h1>Storage</h1>
-      <CacheDuration store={store} player={player} />
-      <AudioFolderComponent store={store} />
-      <h1>Audio</h1>
-      <AudioOptions store={store} />
+      <SettingSection title="Storage">
+        <CacheDuration store={store} player={player} />
+        <AudioFolderComponent store={store} />
+      </SettingSection>
+
+      <SettingSection title="Audio">
+        <AudioOptions store={store} />
+      </SettingSection>
     </>
   );
 });
@@ -469,17 +467,17 @@ const TestVoiceComponent: React.FC<{
               <span style={{ marginRight: "0.5em" }}>
                 {isPlaying ? <Pause size={16} /> : <Play size={16} />}
               </span>
-            )}{" "}
-            Test Voice
+            )}
+            {isPlaying ? "Stop" : "Play"}
           </button>
         </div>
       </div>
       <div>
         <textarea
+          className="tts-settings-textarea tts-test-voice-textarea"
           rows={3}
           value={testText}
           onChange={onTextChange}
-          style={{ width: "100%", marginBottom: "0.5em" }}
           placeholder="Enter text to test..."
         />
       </div>

--- a/src/components/settings/setting-components.tsx
+++ b/src/components/settings/setting-components.tsx
@@ -6,6 +6,32 @@ import {
 } from "../../player/TTSPluginSettings";
 import { OptionSelect } from "./option-select";
 
+// Setting section component for grouping related settings with a heading
+export interface SettingSectionProps {
+  title?: string;
+  /** Optional control element to place in the heading row (e.g., a dropdown) */
+  control?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const SettingSection: React.FC<SettingSectionProps> = ({
+  title,
+  control,
+  children,
+}) => {
+  return (
+    <div className="setting-group">
+      <div className="setting-item setting-item-heading">
+        <div className="setting-item-info">
+          {title && <div className="setting-item-name">{title}</div>}
+        </div>
+        {control && <div className="setting-item-control">{control}</div>}
+      </div>
+      <div className="setting-items">{children}</div>
+    </div>
+  );
+};
+
 // Common props for all setting components
 interface BaseSettingProps {
   name: string;
@@ -181,7 +207,7 @@ export const TextareaSetting: React.FC<TextareaSettingProps> = observer(
           onChange={onChange}
           placeholder={placeholder}
           rows={rows}
-          className="tts-instructions-textarea"
+          className="tts-settings-textarea"
         />
       </div>
     );

--- a/src/web/web-styles.css
+++ b/src/web/web-styles.css
@@ -204,6 +204,60 @@ dialog::backdrop {
    ================================================================= */
 
 /* Emulate Obsidian's setting component styles that shared components depend on */
+
+/* Setting groups - container for related settings with a heading */
+.setting-group {
+  margin-bottom: 24px;
+}
+
+.setting-group:last-child {
+  margin-bottom: 0;
+}
+
+/* Setting item heading - section headers that look like h1 in Obsidian */
+.setting-item.setting-item-heading {
+  border-bottom: 1px solid var(--border-secondary);
+  padding: 12px 0;
+  margin-bottom: 0;
+}
+
+.setting-item.setting-item-heading .setting-item-info {
+  margin-right: 16px;
+}
+
+.setting-item.setting-item-heading .setting-item-name {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0;
+}
+
+/* Setting items container - wraps the actual settings under a heading */
+.setting-items {
+  padding-left: 0;
+}
+
+/* Test voice textarea */
+.tts-test-voice-textarea {
+  width: 100%;
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border-primary);
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 14px;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.tts-test-voice-textarea:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px rgba(0, 122, 204, 0.12);
+}
+
+/* Regular setting items */
 .setting-item {
   display: flex;
   align-items: flex-start;
@@ -212,7 +266,7 @@ dialog::backdrop {
   border-bottom: 1px solid var(--border-primary);
 }
 
-.setting-item:last-child {
+.setting-items > .setting-item:last-child {
   border-bottom: none;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -191,9 +191,13 @@
   margin-top: 4px;
 }
 
-.tts-instructions-textarea {
+.tts-settings-textarea {
   width: 100%;
   margin-top: 12px;
+}
+
+.tts-test-voice-textarea {
+  min-height: 100px;
 }
 
 .tts-settings-block {


### PR DESCRIPTION
The settings headings disappeared in 1.11. Adjust to use the new group styles

<img width="1117" height="939" alt="image" src="https://github.com/user-attachments/assets/cdfc7e66-b7ae-4403-a2ef-167cdcaec081" />
