### PR TITLE
feat(polly): Add AWS profile authentication support

### DIFF
--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -97,3 +97,16 @@ export interface TooltipOptions {
   delay?: number;
   placement?: string;
 }
+
+// Mock Platform
+export const Platform = {
+  isDesktopApp: false,
+  isMobileApp: false,
+  isMobile: false,
+  isIosApp: false,
+  isAndroidApp: false,
+  isMacOS: false,
+  isWin: false,
+  isLinux: false,
+  isSafari: false,
+};

--- a/src/models/aws-profile.test.ts
+++ b/src/models/aws-profile.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { _testing } from "./aws-profile";
+
+const { parseCredentialsFile } = _testing;
+
+describe("parseCredentialsFile", () => {
+  it("should parse default profile credentials", () => {
+    const content = `[default]
+aws_access_key_id = AKIATEST1234567890AB
+aws_secret_access_key = TestSecretKey1234567890abcdefghijklmnop
+`;
+    const result = parseCredentialsFile(content, "default");
+    expect(result).toEqual({
+      accessKeyId: "AKIATEST1234567890AB",
+      secretAccessKey: "TestSecretKey1234567890abcdefghijklmnop",
+    });
+  });
+
+  it("should parse named profile credentials", () => {
+    const content = `[default]
+aws_access_key_id = DEFAULT_KEY
+aws_secret_access_key = DEFAULT_SECRET
+
+[my-profile]
+aws_access_key_id = AKIATEST1234567890AB
+aws_secret_access_key = TestSecretKey1234567890abcdefghijklmnop
+`;
+    const result = parseCredentialsFile(content, "my-profile");
+    expect(result).toEqual({
+      accessKeyId: "AKIATEST1234567890AB",
+      secretAccessKey: "TestSecretKey1234567890abcdefghijklmnop",
+    });
+  });
+
+  it("should parse credentials with session token", () => {
+    const content = `[default]
+aws_access_key_id = AKIATEST1234567890AB
+aws_secret_access_key = TestSecretKey1234567890abcdefghijklmnop
+aws_session_token = TestSessionToken1234567890
+`;
+    const result = parseCredentialsFile(content, "default");
+    expect(result).toEqual({
+      accessKeyId: "AKIATEST1234567890AB",
+      secretAccessKey: "TestSecretKey1234567890abcdefghijklmnop",
+      sessionToken: "TestSessionToken1234567890",
+    });
+  });
+
+  it("should return null for non-existent profile", () => {
+    const content = `[default]
+aws_access_key_id = AKIATEST1234567890AB
+aws_secret_access_key = TestSecretKey1234567890abcdefghijklmnop
+`;
+    const result = parseCredentialsFile(content, "nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for profile with missing access key", () => {
+    const content = `[incomplete]
+aws_secret_access_key = TestSecretKey1234567890abcdefghijklmnop
+`;
+    const result = parseCredentialsFile(content, "incomplete");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for profile with missing secret key", () => {
+    const content = `[incomplete]
+aws_access_key_id = AKIATEST1234567890AB
+`;
+    const result = parseCredentialsFile(content, "incomplete");
+    expect(result).toBeNull();
+  });
+
+  it("should handle comments and empty lines", () => {
+    const content = `# This is a comment
+[default]
+; Another comment style
+aws_access_key_id = AKIATEST1234567890AB
+
+aws_secret_access_key = TestSecretKey1234567890abcdefghijklmnop
+`;
+    const result = parseCredentialsFile(content, "default");
+    expect(result).toEqual({
+      accessKeyId: "AKIATEST1234567890AB",
+      secretAccessKey: "TestSecretKey1234567890abcdefghijklmnop",
+    });
+  });
+
+  it("should handle keys with different casing", () => {
+    const content = `[default]
+AWS_ACCESS_KEY_ID = AKIATEST1234567890AB
+AWS_SECRET_ACCESS_KEY = TestSecretKey1234567890abcdefghijklmnop
+`;
+    const result = parseCredentialsFile(content, "default");
+    expect(result).toEqual({
+      accessKeyId: "AKIATEST1234567890AB",
+      secretAccessKey: "TestSecretKey1234567890abcdefghijklmnop",
+    });
+  });
+
+  it("should handle values with spaces around equals sign", () => {
+    const content = `[default]
+aws_access_key_id=AKIATEST1234567890AB
+aws_secret_access_key =TestSecretKey1234567890abcdefghijklmnop
+`;
+    const result = parseCredentialsFile(content, "default");
+    expect(result).toEqual({
+      accessKeyId: "AKIATEST1234567890AB",
+      secretAccessKey: "TestSecretKey1234567890abcdefghijklmnop",
+    });
+  });
+
+  it("should return null for empty content", () => {
+    const result = parseCredentialsFile("", "default");
+    expect(result).toBeNull();
+  });
+
+  it("should stop parsing at next profile header", () => {
+    const content = `[first]
+aws_access_key_id = FIRST_KEY
+aws_secret_access_key = FIRST_SECRET
+
+[second]
+aws_access_key_id = SECOND_KEY
+aws_secret_access_key = SECOND_SECRET
+`;
+    const result = parseCredentialsFile(content, "first");
+    expect(result).toEqual({
+      accessKeyId: "FIRST_KEY",
+      secretAccessKey: "FIRST_SECRET",
+    });
+  });
+});

--- a/src/models/aws-profile.ts
+++ b/src/models/aws-profile.ts
@@ -1,0 +1,246 @@
+/**
+ * AWS Profile credential provider for Obsidian (Desktop only)
+ *
+ * Reads credentials from ~/.aws/credentials file and supports
+ * automatic refresh via configurable shell commands.
+ *
+ * SECURITY NOTE: The refresh command is executed in a shell. Users should
+ * only configure commands they trust. The command output is not logged
+ * to prevent accidental credential exposure.
+ */
+
+import { Platform } from "obsidian";
+
+export interface AWSCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
+export interface CredentialRefreshResult {
+  success: boolean;
+  error?: string;
+}
+
+// Prevent concurrent refresh operations
+let isRefreshing = false;
+
+/**
+ * Check if we're running on desktop (Node.js available)
+ */
+export function isDesktopApp(): boolean {
+  return Platform.isDesktopApp;
+}
+
+/**
+ * Parse AWS credentials file content (INI format)
+ */
+function parseCredentialsFile(
+  content: string,
+  profile: string,
+): AWSCredentials | null {
+  const lines = content.split("\n");
+  let currentProfile: string | null = null;
+  let credentials: Partial<AWSCredentials> = {};
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip empty lines and comments
+    if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith(";")) {
+      continue;
+    }
+
+    // Check for profile header
+    const profileMatch = trimmed.match(/^\[([^\]]+)\]$/);
+    if (profileMatch) {
+      // If we were in the target profile, we're done
+      if (currentProfile === profile && credentials.accessKeyId) {
+        break;
+      }
+      currentProfile = profileMatch[1];
+      if (currentProfile === profile) {
+        credentials = {};
+      }
+      continue;
+    }
+
+    // Parse key=value if we're in the target profile
+    if (currentProfile === profile) {
+      const keyValueMatch = trimmed.match(/^([^=]+)=(.*)$/);
+      if (keyValueMatch) {
+        const key = keyValueMatch[1].trim().toLowerCase();
+        const value = keyValueMatch[2].trim();
+
+        switch (key) {
+          case "aws_access_key_id":
+            credentials.accessKeyId = value;
+            break;
+          case "aws_secret_access_key":
+            credentials.secretAccessKey = value;
+            break;
+          case "aws_session_token":
+            credentials.sessionToken = value;
+            break;
+        }
+      }
+    }
+  }
+
+  if (credentials.accessKeyId && credentials.secretAccessKey) {
+    return credentials as AWSCredentials;
+  }
+
+  return null;
+}
+
+/**
+ * Read AWS credentials from the credentials file for a specific profile
+ */
+export async function readProfileCredentials(
+  profile: string,
+): Promise<AWSCredentials | null> {
+  if (!isDesktopApp()) {
+    console.warn("AWS profile credentials are only available on desktop");
+    return null;
+  }
+
+  try {
+    // Use require for Node.js APIs in Electron (avoid Vite analysis issues)
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const os = window.require("os");
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const path = window.require("path");
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = window.require("fs");
+
+    const credentialsPath = path.join(os.homedir(), ".aws", "credentials");
+    const content = fs.readFileSync(credentialsPath, "utf-8");
+
+    return parseCredentialsFile(content, profile);
+  } catch (error) {
+    console.error("Failed to read AWS credentials file:", error);
+    return null;
+  }
+}
+
+/**
+ * Execute a shell command to refresh AWS credentials.
+ *
+ * SECURITY: The command is executed in a login shell to pick up PATH.
+ * Command output is intentionally not logged to prevent credential exposure.
+ */
+export async function runRefreshCommand(
+  command: string,
+): Promise<CredentialRefreshResult> {
+  if (!isDesktopApp()) {
+    return {
+      success: false,
+      error: "Credential refresh is only available on desktop",
+    };
+  }
+
+  if (!command.trim()) {
+    return {
+      success: false,
+      error: "No refresh command configured",
+    };
+  }
+
+  // Prevent concurrent refresh operations
+  if (isRefreshing) {
+    return {
+      success: false,
+      error: "Credential refresh already in progress",
+    };
+  }
+
+  isRefreshing = true;
+
+  try {
+    // Use require for Node.js APIs in Electron (avoid Vite analysis issues)
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const childProcess = window.require("child_process");
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const os = window.require("os");
+
+    // Determine the user's default shell (fallback to common shells)
+    const userShell = process.env.SHELL || "/bin/zsh";
+
+    // Execute in a login shell to pick up PATH from shell profile
+    // Using -i for interactive (sources .zshrc/.bashrc) and -l for login shell
+    return await new Promise<CredentialRefreshResult>((resolve) => {
+      const child = childProcess.exec(
+        `${userShell} -i -l -c ${JSON.stringify(command)}`,
+        {
+          timeout: 60000, // 60 second timeout
+          env: {
+            ...process.env,
+            HOME: os.homedir(),
+          },
+        },
+        (error: Error | null, _stdout: string, _stderr: string) => {
+          // Intentionally not logging stdout/stderr to prevent credential exposure
+          if (error) {
+            // Extract just the exit code or a generic message, not full error details
+            const exitCode = (error as NodeJS.ErrnoException).code;
+            resolve({
+              success: false,
+              error: exitCode
+                ? `Refresh command failed (exit code: ${exitCode})`
+                : "Refresh command failed",
+            });
+          } else {
+            resolve({ success: true });
+          }
+        },
+      );
+
+      // Handle timeout
+      child.on("error", () => {
+        resolve({
+          success: false,
+          error: "Refresh command failed to start",
+        });
+      });
+    });
+  } finally {
+    isRefreshing = false;
+  }
+}
+
+/**
+ * Get AWS credentials, optionally refreshing them first
+ */
+export async function getCredentialsWithRefresh(
+  profile: string,
+  refreshCommand: string,
+  forceRefresh: boolean = false,
+): Promise<{ credentials: AWSCredentials | null; refreshed: boolean }> {
+  // First try to read existing credentials
+  let credentials = await readProfileCredentials(profile);
+
+  // If we have credentials and don't need to force refresh, return them
+  if (credentials && !forceRefresh) {
+    return { credentials, refreshed: false };
+  }
+
+  // If no credentials or force refresh, try to refresh
+  if (refreshCommand.trim()) {
+    const refreshResult = await runRefreshCommand(refreshCommand);
+
+    if (refreshResult.success) {
+      // Re-read credentials after refresh
+      credentials = await readProfileCredentials(profile);
+      return { credentials, refreshed: true };
+    }
+    // Refresh failed - fall through to return existing credentials (if any)
+  }
+
+  return { credentials, refreshed: false };
+}
+
+// Export for testing
+export const _testing = {
+  parseCredentialsFile,
+};

--- a/src/player/TTSPluginSettings.ts
+++ b/src/player/TTSPluginSettings.ts
@@ -120,11 +120,19 @@ export interface MinimaxModelConfig {
   minimax_useChinaEndpoint: boolean;
 }
 
+export type PollyAuthMode = "static" | "profile";
+
 export interface PollyModelConfig {
-  /** AWS Access Key ID */
+  /** Authentication mode: static credentials or AWS profile */
+  polly_authMode: PollyAuthMode;
+  /** AWS Access Key ID (used when authMode is 'static') */
   polly_accessKeyId: string;
-  /** AWS Secret Access Key */
+  /** AWS Secret Access Key (used when authMode is 'static') */
   polly_secretAccessKey: string;
+  /** AWS profile name (used when authMode is 'profile') */
+  polly_profile: string;
+  /** Command to refresh AWS credentials (e.g., 'mwinit -s -f') */
+  polly_refreshCommand: string;
   /** AWS region (e.g., us-east-1) */
   polly_region: string;
   /** Polly voice id to use (e.g., Joanna) */
@@ -222,8 +230,11 @@ export const DEFAULT_SETTINGS: TTSPluginSettings = {
   inworld_voiceId: "Ronald",
 
   // polly
+  polly_authMode: "static",
   polly_accessKeyId: "",
   polly_secretAccessKey: "",
+  polly_profile: "default",
+  polly_refreshCommand: "",
   polly_region: "us-east-1",
   polly_voiceId: "Joanna",
   polly_engine: "neural",


### PR DESCRIPTION
## Summary

Adds enterprise-friendly AWS profile authentication for AWS Polly:

- **Profile Selection**: Use credentials from `~/.aws/credentials` instead of storing keys in Obsidian
- **Session Token Support**: Works with temporary credentials (SSO, assume-role, etc.)
- **Automatic Refresh**: Configure a shell command to auto-refresh expired credentials on 401/403
- **Manual Refresh**: Button in settings to manually trigger credential refresh

## Motivation

Many enterprise environments use AWS SSO or assumed roles rather than static credentials. This makes it difficult to use AWS Polly since credentials expire.

## Changes

**New files:**
- `src/models/aws-profile.ts` - Credential provider for reading profiles and running refresh commands
- `src/models/aws-profile.test.ts` - Unit tests for credential file parsing (11 tests)

**Modified files:**
- `src/player/TTSPluginSettings.ts` - New config fields (`polly_authMode`, `polly_profile`, `polly_refreshCommand`)
- `src/models/polly.ts` - Profile auth support with auto-refresh on auth errors
- `src/components/settings/providers/provider-polly.tsx` - Auth mode selector UI
- `__mocks__/obsidian.ts` - Platform mock for tests

## Security Considerations

- Credentials are read from `~/.aws/credentials`, not stored in Obsidian settings
- Command output is not logged to prevent credential exposure
- Concurrent refresh operations prevented with mutex
- Refresh command exit codes are checked

## Desktop Only

This feature requires Node.js filesystem access. UI gracefully falls back to static credentials on mobile.

## Test Plan

- [x] All existing tests pass
- [x] 11 new unit tests for credential file parsing
- [ ] Manual testing with AWS SSO profile
- [ ] Manual testing with static credentials (existing behavior)