### PR TITLE
fix: correct MiniMax API endpoint URLs and add speech-2.8 models

### DIFF
--- a/src/components/settings/providers/provider-minimax.tsx
+++ b/src/components/settings/providers/provider-minimax.tsx
@@ -13,7 +13,7 @@ export const MinimaxSettings = observer(
   ({ store }: { store: TTSPluginSettingsStore }) => {
     const useChinaEndpoint = store.settings.minimax_useChinaEndpoint;
     const helpUrl = useChinaEndpoint
-      ? "https://platform.minimaxi.com/user-center/basic-information/interface-key"
+      ? "https://platform.minimax.chat/user-center/basic-information/interface-key"
       : "https://platform.minimax.io/user-center/basic-information/interface-key";
 
     return (
@@ -25,11 +25,11 @@ export const MinimaxSettings = observer(
               Enable this if you have an API key from the China mainland
               platform (
               <a
-                href="https://platform.minimaxi.com"
+                href="https://platform.minimax.chat"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                platform.minimaxi.com
+                platform.minimax.chat
               </a>
               ). Leave disabled for the international platform (
               <a
@@ -70,6 +70,8 @@ export const MinimaxSettings = observer(
 );
 
 const MINIMAX_MODELS = [
+  { label: "speech-2.8-hd", value: "speech-2.8-hd" },
+  { label: "speech-2.8-turbo", value: "speech-2.8-turbo" },
   { label: "speech-2.6-hd", value: "speech-2.6-hd" },
   { label: "speech-2.6-turbo", value: "speech-2.6-turbo" },
   { label: "speech-02-hd", value: "speech-02-hd" },

--- a/src/models/minimax.ts
+++ b/src/models/minimax.ts
@@ -9,10 +9,10 @@ import {
 import { hexToArrayBuffer } from "../util/misc";
 import { AudioData } from "./tts-model";
 
-/** International endpoint (platform.minimax.io) */
-export const MINIMAX_API_URL = "https://api.minimax.io";
-/** China mainland endpoint (platform.minimaxi.com) */
-export const MINIMAX_CHINA_API_URL = "https://api.minimaxi.com";
+/** International/global endpoint (platform.minimax.io) */
+export const MINIMAX_API_URL = "https://api.minimaxi.chat";
+/** China mainland endpoint (platform.minimax.chat) */
+export const MINIMAX_CHINA_API_URL = "https://api.minimax.chat";
 
 /** Get the appropriate Minimax API URL based on settings */
 export function getMinimaxApiUrl(settings: TTSPluginSettings): string {

--- a/src/player/TTSPluginSettings.ts
+++ b/src/player/TTSPluginSettings.ts
@@ -116,7 +116,7 @@ export interface MinimaxModelConfig {
   minimax_ttsModel: string;
   /** the voice id to use */
   minimax_ttsVoice: string;
-  /** whether to use the China mainland endpoint (api.minimaxi.com) instead of international (api.minimax.io) */
+  /** whether to use the China mainland endpoint (api.minimax.chat) instead of international (api.minimaxi.chat) */
   minimax_useChinaEndpoint: boolean;
 }
 


### PR DESCRIPTION
## Summary

- **Fixes incorrect MiniMax API endpoint URLs** that caused all users to receive \"Invalid API key\" errors regardless of their actual key
- Corrects the China mainland platform help URL in the settings UI
- Adds the latest `speech-2.8-hd` and `speech-2.8-turbo` models to the model selector

## Root Cause

The international and China mainland API base URLs were wrong/swapped:

| | Before (wrong) | After (correct) |
|---|---|---|
| International | `api.minimax.io` | `api.minimaxi.chat` |
| China mainland | `api.minimaxi.com` | `api.minimax.chat` |

The naming convention: domains with an extra **'i'** (`minimax**i**`) are for the **international** platform; without the 'i' (`minimax`) are for **China mainland**. The official [MiniMax MCP-JS README](https://github.com/MiniMax-AI/MiniMax-MCP-JS) explicitly warns: *"API HOST & KEY are different in different region, they must match, otherwise you will receive an Invalid API key error."*

Because the endpoints were wrong, the API always rejected requests with an authentication error — making MiniMax TTS completely non-functional out of the box.

## Changes

- `src/models/minimax.ts`: Fix `MINIMAX_API_URL` and `MINIMAX_CHINA_API_URL` constants
- `src/player/TTSPluginSettings.ts`: Update JSDoc comment to reflect correct domains
- `src/components/settings/providers/provider-minimax.tsx`: Fix China platform help URL; add `speech-2.8-hd` and `speech-2.8-turbo` to model list

## Test plan

- [x] Confirmed working with international endpoint (`api.minimaxi.chat`) using a valid API key and GroupId
- [x] All 18 existing MiniMax unit tests pass (`pnpm run test`)
- [x] Speech-2.8-hd model produces audio successfully in web dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)