### PR TITLE
Add Fish Audio TTS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Just add your API key from a supported provider. Choose from available voices.
 *   **Google Gemini:** (Gemini 2.5 series)
 *   **Hume AI:** (Hume voices with customization)
 *   **ElevenLabs:** (Model selection, voice selection, stability/similarity options)
+*   **Fish Audio:** (S2 Pro/S1 models with custom voice model IDs)
 *   **Azure Speech Services:** (Region, voice and output format selection)
 *   **MiniMax:** (speech-2.6-hd, speech-2.6-turbo, speech-02-hd, speech-02-turbo, speech-01-hd, speech-01-turbo)
 *   **AWS Polly:** (Region, voice, neural/standard engine, output format)

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -11,7 +11,7 @@ The Aloud TTS plugin offers a variety of settings to customize your text-to-spee
 
 These settings control the core behavior of the plugin.
 
--   **TTS Provider**: Choose the text-to-speech service you want to use. Each provider offers different voices and pricing. Supported providers include OpenAI, Google Gemini, ElevenLabs, Inworld, many other TTS providers, and any OpenAI-compatible API.
+-   **TTS Provider**: Choose the text-to-speech service you want to use. Each provider offers different voices and pricing. Supported providers include OpenAI, Google Gemini, ElevenLabs, Fish Audio, Inworld, many other TTS providers, and any OpenAI-compatible API.
 -   **Playback Speed**: Adjust the default playback speed. The default is `1.0x`. This can also be adjusted from the player UI.
 -   **Audio Folder**: The directory in your vault where exported audio files are saved. The default is `aloud/`.
 
@@ -70,6 +70,20 @@ For users who self-host a TTS service or use a third-party provider with an Open
 -   **Stability**: Controls how stable/consistent the voice is (0–1).
 -   **Similarity Boost**: Controls how closely the output matches the base voice (0–1).
 -   **Context Mode**: Optionally include previous sentences for continuity.
+
+### Fish Audio
+
+-   **API Key**: Your API key from [Fish Audio](https://fish.audio/app/api-keys).
+-   **Model**: The Fish Audio TTS model to use: `S2 Pro` or `S1`.
+-   **Voice Source**: Choose `My Voices` to load voices from your Fish Audio account after entering a valid API key, or choose `Custom Voice ID` to enter a model ID manually.
+-   **Voice**: The Fish Audio voice model ID to use as the API `reference_id`.
+-   **Custom Voice ID**: A voice model ID for unlisted or shared Fish Audio voices. Fish Audio uses `reference_id` to point TTS requests at a voice model.
+-   **Sentence Pause**: Optionally insert Fish Audio pause controls between sentences. Use this when a voice sounds good but moves too quickly into the next sentence.
+
+Notes:
+-   Fish Audio API requests use your own Fish Audio account and billing.
+-   `S2 Pro` is the default model and supports Fish Audio's latest TTS features. `S1` is also available for voices or workflows that work better with that model.
+-   If you use `Custom Voice ID`, copy the model ID from Fish Audio and paste it into the setting exactly.
 
 ### Azure Speech Services
 

--- a/docs/src/content/docs/features/index.md
+++ b/docs/src/content/docs/features/index.md
@@ -5,4 +5,4 @@ description: A high-level overview of the features available in the Aloud TTS pl
 
 The Aloud TTS plugin is packed with features designed to provide a seamless text-to-speech experience within Obsidian. Explore the sections below to learn more about each capability. 
 
-Supported providers include OpenAI, Google Gemini, Hume AI, Azure, ElevenLabs, MiniMax, and custom OpenAI-compatible backends.
+Supported providers include OpenAI, Google Gemini, Hume AI, Azure, ElevenLabs, Fish Audio, MiniMax, and custom OpenAI-compatible backends.

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -23,7 +23,7 @@ After installing the plugin, you need to configure a TTS provider to enable text
 
     <!-- `[INSERT SCREENSHOT: settings_panel_location.png]` -->
 
-2.  **Choose a TTS Provider**: Select a provider from the dropdown menu, such as OpenAI, Google Gemini, Hume AI, or Inworld.
+2.  **Choose a TTS Provider**: Select a provider from the dropdown menu, such as OpenAI, Google Gemini, Hume AI, Fish Audio, or Inworld.
 
     <!-- `[INSERT SCREENSHOT: provider_selection.png]` -->
 
@@ -44,4 +44,4 @@ To test your setup:
 3.  Open the Command Palette (`Cmd/Ctrl+P`).
 4.  Search for "Speak selection" and run the command.
 
-Audio should begin playing shortly, and the currently spoken sentence will be highlighted in the editor. 
+Audio should begin playing shortly, and the currently spoken sentence will be highlighted in the editor.

--- a/src/components/TTSPluginSettingsTab.test.tsx
+++ b/src/components/TTSPluginSettingsTab.test.tsx
@@ -16,6 +16,7 @@ vi.mock("./IconButton", () => ({
     <button onClick={onClick}>{children}</button>
   ),
   IconSpan: ({ children }: any) => <span>{children}</span>,
+  TooltipSpan: ({ children }: any) => <span>{children}</span>,
   Spinner: () => <div>Loading...</div>,
 }));
 

--- a/src/components/TTSSettingsTabComponent.tsx
+++ b/src/components/TTSSettingsTabComponent.tsx
@@ -23,6 +23,7 @@ import { OpenAICompatibleSettings } from "./settings/providers/provider-openai-l
 import { MinimaxSettings } from "./settings/providers/provider-minimax";
 import { InworldSettings } from "./settings/providers/provider-inworld";
 import { PollySettings } from "./settings/providers/provider-polly";
+import { FishSettings } from "./settings/providers/provider-fish";
 
 export const TTSSettingsTabComponent: React.FC<{
   store: TTSPluginSettingsStore;
@@ -65,6 +66,9 @@ export const TTSSettingsTabComponent: React.FC<{
         )}
         {store.settings.modelProvider === "minimax" && (
           <MinimaxSettings store={store} />
+        )}
+        {store.settings.modelProvider === "fish" && (
+          <FishSettings store={store} />
         )}
         {store.settings.modelProvider === "inworld" && (
           <InworldSettings store={store} />
@@ -149,6 +153,7 @@ const labels: Record<ModelProvider, string> = {
   gemini: "Google Gemini",
   hume: "Hume",
   minimax: "MiniMax",
+  fish: "Fish Audio",
   inworld: "Inworld",
   polly: "AWS Polly",
 };

--- a/src/components/settings/providers/provider-fish.tsx
+++ b/src/components/settings/providers/provider-fish.tsx
@@ -28,6 +28,7 @@ export const FishSettings = observer(
         ) : (
           <FishCustomVoiceComponent store={store} />
         )}
+        <FishSentencePauseComponent store={store} />
       </>
     );
   },
@@ -174,6 +175,27 @@ const FishCustomVoiceComponent: React.FC<{
       provider="fish"
       fieldName="fish_voiceId"
       placeholder="e.g. 7f92f8afb8ec43bf81429cc1c9199cb1"
+    />
+  );
+});
+
+const FISH_SENTENCE_PAUSES = [
+  { label: "None", value: "none" },
+  { label: "Short", value: "short" },
+  { label: "Long", value: "long" },
+] as const;
+
+const FishSentencePauseComponent: React.FC<{
+  store: TTSPluginSettingsStore;
+}> = observer(({ store }) => {
+  return (
+    <OptionSelectSetting
+      name="Sentence Pause"
+      description="Add Fish Audio pause controls between sentences. Use this when a voice reads at the right pace but moves too quickly into the next sentence."
+      store={store}
+      provider="fish"
+      fieldName="fish_sentencePause"
+      options={FISH_SENTENCE_PAUSES}
     />
   );
 });

--- a/src/components/settings/providers/provider-fish.tsx
+++ b/src/components/settings/providers/provider-fish.tsx
@@ -1,0 +1,179 @@
+import { observer } from "mobx-react-lite";
+import React from "react";
+import {
+  FishVoiceSource,
+  TTSPluginSettingsStore,
+} from "../../../player/TTSPluginSettings";
+import { FishVoice, listFishVoices } from "../../../models/fish";
+import { ApiKeyComponent } from "../api-key-component";
+import { OptionSelect } from "../option-select";
+import { OptionSelectSetting, TextInputSetting } from "../setting-components";
+
+export const FishSettings = observer(
+  ({ store }: { store: TTSPluginSettingsStore }) => {
+    return (
+      <>
+        <ApiKeyComponent
+          store={store}
+          provider="fish"
+          fieldName="fish_apiKey"
+          displayName="Fish Audio API key"
+          helpUrl="https://fish.audio/app/api-keys"
+          showValidation={true}
+        />
+        <FishModelComponent store={store} />
+        <FishVoiceSourceComponent store={store} />
+        {store.settings.fish_voiceSource === "my-voices" ? (
+          <FishVoiceSelectComponent store={store} />
+        ) : (
+          <FishCustomVoiceComponent store={store} />
+        )}
+      </>
+    );
+  },
+);
+
+const FISH_MODELS = [
+  { label: "S2 Pro", value: "s2-pro" },
+  { label: "S1", value: "s1" },
+] as const;
+
+const FishModelComponent: React.FC<{
+  store: TTSPluginSettingsStore;
+}> = observer(({ store }) => {
+  return (
+    <OptionSelectSetting
+      name="Model"
+      description="The Fish Audio TTS model to use."
+      store={store}
+      provider="fish"
+      fieldName="fish_model"
+      options={FISH_MODELS}
+    />
+  );
+});
+
+const FishVoiceSourceComponent: React.FC<{
+  store: TTSPluginSettingsStore;
+}> = observer(({ store }) => {
+  const onChange = React.useCallback(
+    (value: string) => {
+      store.updateModelSpecificSettings("fish", {
+        fish_voiceSource: value as FishVoiceSource,
+      });
+    },
+    [store],
+  );
+
+  return (
+    <div className="setting-item">
+      <div className="setting-item-info">
+        <div className="setting-item-name">Voice Source</div>
+        <div className="setting-item-description">
+          Choose from your Fish Audio voices or enter a voice model ID manually.
+        </div>
+      </div>
+      <div className="setting-item-control">
+        <OptionSelect
+          options={[
+            { label: "Custom Voice ID", value: "custom" },
+            { label: "My Voices", value: "my-voices" },
+          ]}
+          value={store.settings.fish_voiceSource}
+          onChange={onChange}
+        />
+      </div>
+    </div>
+  );
+});
+
+const FishVoiceSelectComponent: React.FC<{
+  store: TTSPluginSettingsStore;
+}> = observer(({ store }) => {
+  const [voices, setVoices] = React.useState<FishVoice[]>([]);
+  const [error, setError] = React.useState<string | null>(null);
+  const apiKey = store.settings.fish_apiKey;
+
+  React.useEffect(() => {
+    if (!apiKey) {
+      setVoices([]);
+      setError(null);
+      return;
+    }
+
+    const fetchVoices = async (): Promise<void> => {
+      setError(null);
+      try {
+        const fetchedVoices = await listFishVoices(apiKey, true);
+        setVoices(fetchedVoices);
+
+        const currentVoiceExists = fetchedVoices.some(
+          (voice) => voice.id === store.settings.fish_voiceId,
+        );
+        const firstUsableVoice = fetchedVoices.find(
+          (voice) => voice.state !== "failed" && voice.state !== "training",
+        );
+
+        if (!currentVoiceExists && firstUsableVoice) {
+          store.updateModelSpecificSettings("fish", {
+            fish_voiceId: firstUsableVoice.id,
+          });
+        }
+      } catch (err) {
+        console.error("Failed to fetch Fish Audio voices:", err);
+        setError("Failed to load voices. Please check your API key.");
+        setVoices([]);
+      }
+    };
+
+    fetchVoices();
+  }, [apiKey, store]);
+
+  if (error) {
+    return (
+      <div>
+        <p style={{ color: "var(--text-error)" }}>{error}</p>
+      </div>
+    );
+  }
+
+  if (!apiKey) {
+    return (
+      <div>
+        <p>Enter your API key to load your Fish Audio voices.</p>
+      </div>
+    );
+  }
+
+  const voiceOptions = voices.map((voice) => ({
+    label: `${voice.title} (${voice.visibility})`,
+    value: voice.id,
+    disabled: voice.state === "failed" || voice.state === "training",
+  }));
+
+  return (
+    <OptionSelectSetting
+      name="Voice"
+      description="The Fish Audio voice model to use."
+      store={store}
+      provider="fish"
+      fieldName="fish_voiceId"
+      options={voiceOptions}
+    />
+  );
+});
+
+const FishCustomVoiceComponent: React.FC<{
+  store: TTSPluginSettingsStore;
+}> = observer(({ store }) => {
+  return (
+    <TextInputSetting
+      name="Custom Voice ID"
+      description="The Fish Audio voice model ID to pass as reference_id. Use this for unlisted voices."
+      store={store}
+      provider="fish"
+      fieldName="fish_voiceId"
+      placeholder="e.g. 7f92f8afb8ec43bf81429cc1c9199cb1"
+    />
+  );
+});

--- a/src/models/fish.test.ts
+++ b/src/models/fish.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { RequestUrlResponse, requestUrl } from "obsidian";
 import { DEFAULT_SETTINGS } from "../player/TTSPluginSettings";
 import { TTSModelOptions, TTSErrorInfo } from "./tts-model";
 import {
@@ -10,16 +11,17 @@ import {
   validateApiKeyFish,
 } from "./fish";
 
-describe("Fish Audio Model", () => {
-  const fetchMock = vi.fn<typeof fetch>();
+vi.mock("obsidian", () => ({
+  requestUrl: vi.fn(),
+}));
 
+describe("Fish Audio Model", () => {
   beforeEach(() => {
-    fetchMock.mockReset();
-    vi.stubGlobal("fetch", fetchMock);
+    vi.mocked(requestUrl).mockReset();
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   describe("convertToOptions", () => {
@@ -52,30 +54,27 @@ describe("Fish Audio Model", () => {
     });
 
     it("should validate the API key by listing voices", async () => {
-      fetchMock.mockResolvedValue(
-        new Response(JSON.stringify({ total: 0, items: [] }), {
-          status: 200,
-        }),
+      vi.mocked(requestUrl).mockResolvedValue(
+        fishResponse({ status: 200, json: { total: 0, items: [] } }),
       );
 
       const result = await validateApiKeyFish("valid-key");
 
       expect(result).toBeUndefined();
-      expect(fetchMock).toHaveBeenCalledWith(
-        `${FISH_API_URL}/model?page_size=50&page_number=1&sort_by=created_at&self=true`,
-        {
-          headers: {
-            Authorization: "Bearer valid-key",
-          },
+      expect(requestUrl).toHaveBeenCalledWith({
+        url: `${FISH_API_URL}/model?page_size=50&page_number=1&sort_by=created_at&self=true`,
+        headers: {
+          Authorization: "Bearer valid-key",
         },
-      );
+        throw: false,
+      });
     });
 
     it("should report invalid API keys", async () => {
-      fetchMock.mockResolvedValue(
-        new Response(JSON.stringify({ status: 401, message: "Unauthorized" }), {
+      vi.mocked(requestUrl).mockResolvedValue(
+        fishResponse({
           status: 401,
-          headers: { "Content-Type": "application/json" },
+          json: { status: 401, message: "Unauthorized" },
         }),
       );
 
@@ -94,7 +93,9 @@ describe("Fish Audio Model", () => {
 
     it("should make a Fish Audio TTS request and return mp3 audio", async () => {
       const audio = new Uint8Array([1, 2, 3, 4]).buffer;
-      fetchMock.mockResolvedValue(new Response(audio, { status: 200 }));
+      vi.mocked(requestUrl).mockResolvedValue(
+        fishResponse({ status: 200, arrayBuffer: audio }),
+      );
 
       const result = await fishCallTextToSpeech(
         "Hello world",
@@ -103,11 +104,12 @@ describe("Fish Audio Model", () => {
         {},
       );
 
-      expect(fetchMock).toHaveBeenCalledWith(`${FISH_API_URL}/v1/tts`, {
+      expect(requestUrl).toHaveBeenCalledWith({
+        url: `${FISH_API_URL}/v1/tts`,
         method: "POST",
+        contentType: "application/json",
         headers: {
           Authorization: "Bearer test-api-key",
-          "Content-Type": "application/json",
           model: "s2-pro",
         },
         body: JSON.stringify({
@@ -117,6 +119,7 @@ describe("Fish Audio Model", () => {
           mp3_bitrate: 128,
           normalize: true,
         }),
+        throw: false,
       });
       expect(new Uint8Array(result.data)).toEqual(new Uint8Array(audio));
       expect(result.format).toBe("mp3");
@@ -134,14 +137,11 @@ describe("Fish Audio Model", () => {
     });
 
     it("should map Fish Audio API errors", async () => {
-      fetchMock.mockResolvedValue(
-        new Response(
-          JSON.stringify({ status: 422, message: "Invalid reference_id" }),
-          {
-            status: 422,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
+      vi.mocked(requestUrl).mockResolvedValue(
+        fishResponse({
+          status: 422,
+          json: { status: 422, message: "Invalid reference_id" },
+        }),
       );
 
       try {
@@ -163,9 +163,10 @@ describe("Fish Audio Model", () => {
 
   describe("voice helpers", () => {
     it("should list Fish Audio voices", async () => {
-      fetchMock.mockResolvedValue(
-        new Response(
-          JSON.stringify({
+      vi.mocked(requestUrl).mockResolvedValue(
+        fishResponse({
+          status: 200,
+          json: {
             total: 1,
             items: [
               {
@@ -176,9 +177,8 @@ describe("Fish Audio Model", () => {
                 type: "tts",
               },
             ],
-          }),
-          { status: 200 },
-        ),
+          },
+        }),
       );
 
       const voices = await listFishVoices("test-key", true);
@@ -195,27 +195,47 @@ describe("Fish Audio Model", () => {
     });
 
     it("should get a Fish Audio voice by ID", async () => {
-      fetchMock.mockResolvedValue(
-        new Response(
-          JSON.stringify({
+      vi.mocked(requestUrl).mockResolvedValue(
+        fishResponse({
+          status: 200,
+          json: {
             _id: "voice-id",
             title: "Calm Mystical Narrator",
             visibility: "unlist",
             state: "created",
             type: "tts",
-          }),
-          { status: 200 },
-        ),
+          },
+        }),
       );
 
       const voice = await getFishVoice("test-key", "voice-id");
 
-      expect(fetchMock).toHaveBeenCalledWith(`${FISH_API_URL}/model/voice-id`, {
+      expect(requestUrl).toHaveBeenCalledWith({
+        url: `${FISH_API_URL}/model/voice-id`,
         headers: {
           Authorization: "Bearer test-key",
         },
+        throw: false,
       });
       expect(voice.title).toBe("Calm Mystical Narrator");
     });
   });
 });
+
+function fishResponse({
+  status,
+  json = {},
+  arrayBuffer = new ArrayBuffer(0),
+}: {
+  status: number;
+  json?: unknown;
+  arrayBuffer?: ArrayBuffer;
+}): RequestUrlResponse {
+  return {
+    status,
+    json,
+    arrayBuffer,
+    text: typeof json === "string" ? json : JSON.stringify(json),
+    headers: {},
+  };
+}

--- a/src/models/fish.test.ts
+++ b/src/models/fish.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { DEFAULT_SETTINGS } from "../player/TTSPluginSettings";
+import { TTSModelOptions, TTSErrorInfo } from "./tts-model";
+import {
+  FISH_API_URL,
+  fishCallTextToSpeech,
+  fishTextToSpeech,
+  getFishVoice,
+  listFishVoices,
+  validateApiKeyFish,
+} from "./fish";
+
+describe("Fish Audio Model", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("convertToOptions", () => {
+    it("should convert settings to options correctly", () => {
+      const settings = {
+        ...DEFAULT_SETTINGS,
+        fish_apiKey: "test-api-key",
+        fish_model: "s2-pro" as const,
+        fish_voiceId: "voice-id",
+      };
+
+      const options = fishTextToSpeech.convertToOptions(settings);
+
+      expect(options).toEqual({
+        apiKey: "test-api-key",
+        model: "s2-pro",
+        voice: "voice-id",
+      });
+    });
+  });
+
+  describe("validateConnection", () => {
+    it("should require an API key", async () => {
+      const result = await fishTextToSpeech.validateConnection({
+        ...DEFAULT_SETTINGS,
+        fish_apiKey: "",
+      });
+
+      expect(result).toContain("Please enter an API key");
+    });
+
+    it("should validate the API key by listing voices", async () => {
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ total: 0, items: [] }), {
+          status: 200,
+        }),
+      );
+
+      const result = await validateApiKeyFish("valid-key");
+
+      expect(result).toBeUndefined();
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${FISH_API_URL}/model?page_size=50&page_number=1&sort_by=created_at&self=true`,
+        {
+          headers: {
+            Authorization: "Bearer valid-key",
+          },
+        },
+      );
+    });
+
+    it("should report invalid API keys", async () => {
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ status: 401, message: "Unauthorized" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await validateApiKeyFish("bad-key");
+
+      expect(result).toBe("Invalid API key");
+    });
+  });
+
+  describe("fishCallTextToSpeech", () => {
+    const options: TTSModelOptions = {
+      apiKey: "test-api-key",
+      model: "s2-pro",
+      voice: "voice-id",
+    };
+
+    it("should make a Fish Audio TTS request and return mp3 audio", async () => {
+      const audio = new Uint8Array([1, 2, 3, 4]).buffer;
+      fetchMock.mockResolvedValue(new Response(audio, { status: 200 }));
+
+      const result = await fishCallTextToSpeech(
+        "Hello world",
+        options,
+        DEFAULT_SETTINGS,
+        {},
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(`${FISH_API_URL}/v1/tts`, {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-api-key",
+          "Content-Type": "application/json",
+          model: "s2-pro",
+        },
+        body: JSON.stringify({
+          text: "Hello world",
+          reference_id: "voice-id",
+          format: "mp3",
+          mp3_bitrate: 128,
+          normalize: true,
+        }),
+      });
+      expect(new Uint8Array(result.data)).toEqual(new Uint8Array(audio));
+      expect(result.format).toBe("mp3");
+    });
+
+    it("should throw when no voice ID is configured", async () => {
+      await expect(
+        fishCallTextToSpeech(
+          "Hello world",
+          { ...options, voice: undefined },
+          DEFAULT_SETTINGS,
+          {},
+        ),
+      ).rejects.toThrow("Voice model ID is required for Fish Audio TTS");
+    });
+
+    it("should map Fish Audio API errors", async () => {
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({ status: 422, message: "Invalid reference_id" }),
+          {
+            status: 422,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+
+      try {
+        await fishCallTextToSpeech(
+          "Hello world",
+          options,
+          DEFAULT_SETTINGS,
+          {},
+        );
+        expect.fail("Expected Fish Audio request to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(TTSErrorInfo);
+        expect(error).toMatchObject({
+          httpErrorCode: 422,
+        });
+      }
+    });
+  });
+
+  describe("voice helpers", () => {
+    it("should list Fish Audio voices", async () => {
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            total: 1,
+            items: [
+              {
+                _id: "voice-id",
+                title: "Calm Mystical Narrator",
+                visibility: "unlist",
+                state: "created",
+                type: "tts",
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const voices = await listFishVoices("test-key", true);
+
+      expect(voices).toEqual([
+        {
+          id: "voice-id",
+          title: "Calm Mystical Narrator",
+          visibility: "unlist",
+          state: "created",
+          type: "tts",
+        },
+      ]);
+    });
+
+    it("should get a Fish Audio voice by ID", async () => {
+      fetchMock.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            _id: "voice-id",
+            title: "Calm Mystical Narrator",
+            visibility: "unlist",
+            state: "created",
+            type: "tts",
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const voice = await getFishVoice("test-key", "voice-id");
+
+      expect(fetchMock).toHaveBeenCalledWith(`${FISH_API_URL}/model/voice-id`, {
+        headers: {
+          Authorization: "Bearer test-key",
+        },
+      });
+      expect(voice.title).toBe("Calm Mystical Narrator");
+    });
+  });
+});

--- a/src/models/fish.test.ts
+++ b/src/models/fish.test.ts
@@ -4,6 +4,7 @@ import { DEFAULT_SETTINGS } from "../player/TTSPluginSettings";
 import { TTSModelOptions, TTSErrorInfo } from "./tts-model";
 import {
   FISH_API_URL,
+  addFishSentencePauses,
   fishCallTextToSpeech,
   fishTextToSpeech,
   getFishVoice,
@@ -31,12 +32,14 @@ describe("Fish Audio Model", () => {
         fish_apiKey: "test-api-key",
         fish_model: "s2-pro" as const,
         fish_voiceId: "voice-id",
+        fish_sentencePause: "long" as const,
       };
 
       const options = fishTextToSpeech.convertToOptions(settings);
 
       expect(options).toEqual({
         apiKey: "test-api-key",
+        instructions: "long",
         model: "s2-pro",
         voice: "voice-id",
       });
@@ -125,6 +128,32 @@ describe("Fish Audio Model", () => {
       expect(result.format).toBe("mp3");
     });
 
+    it("should add Fish Audio sentence pause controls", async () => {
+      const audio = new Uint8Array([1, 2, 3, 4]).buffer;
+      vi.mocked(requestUrl).mockResolvedValue(
+        fishResponse({ status: 200, arrayBuffer: audio }),
+      );
+
+      await fishCallTextToSpeech(
+        "Hello world. Next sentence?",
+        { ...options, instructions: "short" },
+        DEFAULT_SETTINGS,
+        {},
+      );
+
+      expect(requestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: JSON.stringify({
+            text: "Hello world. (break) Next sentence? (break)",
+            reference_id: "voice-id",
+            format: "mp3",
+            mp3_bitrate: 128,
+            normalize: false,
+          }),
+        }),
+      );
+    });
+
     it("should throw when no voice ID is configured", async () => {
       await expect(
         fishCallTextToSpeech(
@@ -158,6 +187,26 @@ describe("Fish Audio Model", () => {
           httpErrorCode: 422,
         });
       }
+    });
+  });
+
+  describe("addFishSentencePauses", () => {
+    it("should leave text unchanged when disabled", () => {
+      expect(addFishSentencePauses("Hello. Next.", "none")).toBe(
+        "Hello. Next.",
+      );
+    });
+
+    it("should insert short pauses between sentences and at sentence endings", () => {
+      expect(addFishSentencePauses("Hello. Next?", "short")).toBe(
+        "Hello. (break) Next? (break)",
+      );
+    });
+
+    it("should insert long pauses while preserving trailing whitespace", () => {
+      expect(addFishSentencePauses("Hello. Next.  ", "long")).toBe(
+        "Hello. (long-break) Next. (long-break)  ",
+      );
     });
   });
 

--- a/src/models/fish.ts
+++ b/src/models/fish.ts
@@ -1,5 +1,8 @@
 import { RequestUrlResponse, requestUrl } from "obsidian";
-import { TTSPluginSettings } from "../player/TTSPluginSettings";
+import {
+  FishSentencePause,
+  TTSPluginSettings,
+} from "../player/TTSPluginSettings";
 import {
   AudioTextContext,
   ErrorMessage,
@@ -33,6 +36,7 @@ export const fishTextToSpeech: TTSModel = {
       apiKey: settings.fish_apiKey,
       model: settings.fish_model,
       voice: settings.fish_voiceId,
+      instructions: settings.fish_sentencePause,
     };
   },
 };
@@ -73,6 +77,7 @@ export async function fishCallTextToSpeech(
       },
     });
   }
+  const sentencePause = parseFishSentencePause(options.instructions);
 
   const response = await requestUrl({
     url: `${FISH_API_URL}/v1/tts`,
@@ -83,11 +88,11 @@ export async function fishCallTextToSpeech(
       model: options.model,
     },
     body: JSON.stringify({
-      text,
+      text: addFishSentencePauses(text, sentencePause),
       reference_id: options.voice,
       format: "mp3",
       mp3_bitrate: 128,
-      normalize: true,
+      normalize: sentencePause === "none",
     }),
     throw: false,
   });
@@ -97,6 +102,41 @@ export async function fishCallTextToSpeech(
     data: response.arrayBuffer,
     format: "mp3",
   };
+}
+
+export function addFishSentencePauses(
+  text: string,
+  sentencePause: FishSentencePause,
+): string {
+  const pauseTag = fishPauseTag(sentencePause);
+  if (!pauseTag) {
+    return text;
+  }
+
+  const textWithInternalPauses = text.replace(
+    /([.!?]["')\]]?)(\s+)/g,
+    `$1 ${pauseTag}$2`,
+  );
+
+  return textWithInternalPauses.replace(
+    /([.!?]["')\]]?)(\s*)$/u,
+    `$1 ${pauseTag}$2`,
+  );
+}
+
+function parseFishSentencePause(value: string | undefined): FishSentencePause {
+  return value === "short" || value === "long" ? value : "none";
+}
+
+function fishPauseTag(sentencePause: FishSentencePause): string | undefined {
+  switch (sentencePause) {
+    case "short":
+      return "(break)";
+    case "long":
+      return "(long-break)";
+    case "none":
+      return undefined;
+  }
 }
 
 export async function listFishVoices(

--- a/src/models/fish.ts
+++ b/src/models/fish.ts
@@ -1,0 +1,241 @@
+import { TTSPluginSettings } from "../player/TTSPluginSettings";
+import {
+  AudioTextContext,
+  ErrorMessage,
+  REQUIRE_API_KEY,
+  TTSErrorInfo,
+  TTSModel,
+  TTSModelOptions,
+} from "./tts-model";
+import { AudioData } from "./tts-model";
+
+export const FISH_API_URL = "https://api.fish.audio";
+
+export interface FishVoice {
+  id: string;
+  title: string;
+  visibility: "public" | "unlist" | "private";
+  state: "created" | "training" | "trained" | "failed";
+  type: "svc" | "tts";
+}
+
+export const fishTextToSpeech: TTSModel = {
+  call: fishCallTextToSpeech,
+  validateConnection: async (settings) => {
+    if (!settings.fish_apiKey) {
+      return REQUIRE_API_KEY;
+    }
+    return await validateApiKeyFish(settings.fish_apiKey);
+  },
+  convertToOptions: (settings): TTSModelOptions => {
+    return {
+      apiKey: settings.fish_apiKey,
+      model: settings.fish_model,
+      voice: settings.fish_voiceId,
+    };
+  },
+};
+
+export async function validateApiKeyFish(
+  apiKey: string,
+): Promise<string | undefined> {
+  try {
+    await listFishVoices(apiKey, true);
+    return undefined;
+  } catch (error) {
+    if (error instanceof TTSErrorInfo) {
+      if (error.httpErrorCode === 401 || error.httpErrorCode === 403) {
+        return "Invalid API key";
+      } else if (error.httpErrorCode !== undefined) {
+        return `HTTP error code ${error.httpErrorCode}: ${error.ttsJsonMessage() || error.message}`;
+      } else {
+        return error.ttsJsonMessage() || error.message;
+      }
+    }
+    return "Cannot connect to Fish Audio API";
+  }
+}
+
+export async function fishCallTextToSpeech(
+  text: string,
+  options: TTSModelOptions,
+  _settings: TTSPluginSettings,
+  _context: AudioTextContext = {},
+): Promise<AudioData> {
+  if (!options.voice) {
+    throw new TTSErrorInfo("Voice model ID is required for Fish Audio TTS", {
+      error: {
+        message: "Voice model ID is required for Fish Audio TTS",
+        type: "invalid_request_error",
+        code: "missing_voice",
+        param: null,
+      },
+    });
+  }
+
+  const response = await fetch(`${FISH_API_URL}/v1/tts`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${options.apiKey || ""}`,
+      "Content-Type": "application/json",
+      model: options.model,
+    },
+    body: JSON.stringify({
+      text,
+      reference_id: options.voice,
+      format: "mp3",
+      mp3_bitrate: 128,
+      normalize: true,
+    }),
+  });
+
+  await validate200Fish(response);
+  return {
+    data: await response.arrayBuffer(),
+    format: "mp3",
+  };
+}
+
+export async function listFishVoices(
+  apiKey: string,
+  self: boolean,
+): Promise<FishVoice[]> {
+  if (!apiKey) {
+    return [];
+  }
+
+  const params = new URLSearchParams({
+    page_size: "50",
+    page_number: "1",
+    sort_by: "created_at",
+  });
+  if (self) {
+    params.set("self", "true");
+  }
+
+  const response = await fetch(`${FISH_API_URL}/model?${params.toString()}`, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  await validate200Fish(response);
+  const data = await response.json();
+  return parseFishVoiceList(data);
+}
+
+export async function getFishVoice(
+  apiKey: string,
+  voiceId: string,
+): Promise<FishVoice> {
+  const response = await fetch(
+    `${FISH_API_URL}/model/${encodeURIComponent(voiceId)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    },
+  );
+
+  await validate200Fish(response);
+  return parseFishVoice(await response.json());
+}
+
+export async function validate200Fish(response: Response): Promise<void> {
+  if (response.status < 300) {
+    return;
+  }
+
+  let errorMessage: ErrorMessage | undefined;
+  try {
+    errorMessage = fishErrorMessage(await response.json(), response.status);
+  } catch {
+    errorMessage = undefined;
+  }
+
+  throw new TTSErrorInfo(
+    `HTTP ${response.status} error`,
+    errorMessage,
+    response.status,
+  );
+}
+
+function fishErrorMessage(body: unknown, status: number): ErrorMessage {
+  const bodyRecord = isRecord(body) ? body : {};
+  const message = readString(bodyRecord, "message") ?? "Unknown error";
+  const statusCode =
+    readNumber(bodyRecord, "status")?.toString() ?? status.toString();
+
+  return {
+    error: {
+      message,
+      type: "fish_audio_error",
+      code: statusCode,
+      param: null,
+    },
+  };
+}
+
+function parseFishVoiceList(data: unknown): FishVoice[] {
+  if (!isRecord(data) || !Array.isArray(data.items)) {
+    return [];
+  }
+  return data.items.map(parseFishVoice);
+}
+
+function parseFishVoice(data: unknown): FishVoice {
+  const record = isRecord(data) ? data : {};
+  return {
+    id: readString(record, "_id") ?? "",
+    title: readString(record, "title") ?? "Untitled voice",
+    visibility: parseVisibility(readString(record, "visibility")),
+    state: parseState(readString(record, "state")),
+    type: parseType(readString(record, "type")),
+  };
+}
+
+function parseVisibility(value: string | undefined): FishVoice["visibility"] {
+  if (value === "private" || value === "unlist" || value === "public") {
+    return value;
+  }
+  return "public";
+}
+
+function parseState(value: string | undefined): FishVoice["state"] {
+  if (
+    value === "created" ||
+    value === "training" ||
+    value === "trained" ||
+    value === "failed"
+  ) {
+    return value;
+  }
+  return "created";
+}
+
+function parseType(value: string | undefined): FishVoice["type"] {
+  if (value === "tts" || value === "svc") {
+    return value;
+  }
+  return "tts";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function readNumber(
+  record: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const value = record[key];
+  return typeof value === "number" ? value : undefined;
+}

--- a/src/models/fish.ts
+++ b/src/models/fish.ts
@@ -1,3 +1,4 @@
+import { RequestUrlResponse, requestUrl } from "obsidian";
 import { TTSPluginSettings } from "../player/TTSPluginSettings";
 import {
   AudioTextContext,
@@ -73,11 +74,12 @@ export async function fishCallTextToSpeech(
     });
   }
 
-  const response = await fetch(`${FISH_API_URL}/v1/tts`, {
+  const response = await requestUrl({
+    url: `${FISH_API_URL}/v1/tts`,
     method: "POST",
+    contentType: "application/json",
     headers: {
       Authorization: `Bearer ${options.apiKey || ""}`,
-      "Content-Type": "application/json",
       model: options.model,
     },
     body: JSON.stringify({
@@ -87,11 +89,12 @@ export async function fishCallTextToSpeech(
       mp3_bitrate: 128,
       normalize: true,
     }),
+    throw: false,
   });
 
   await validate200Fish(response);
   return {
-    data: await response.arrayBuffer(),
+    data: response.arrayBuffer,
     format: "mp3",
   };
 }
@@ -113,42 +116,44 @@ export async function listFishVoices(
     params.set("self", "true");
   }
 
-  const response = await fetch(`${FISH_API_URL}/model?${params.toString()}`, {
+  const response = await requestUrl({
+    url: `${FISH_API_URL}/model?${params.toString()}`,
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },
+    throw: false,
   });
 
   await validate200Fish(response);
-  const data = await response.json();
-  return parseFishVoiceList(data);
+  return parseFishVoiceList(response.json);
 }
 
 export async function getFishVoice(
   apiKey: string,
   voiceId: string,
 ): Promise<FishVoice> {
-  const response = await fetch(
-    `${FISH_API_URL}/model/${encodeURIComponent(voiceId)}`,
-    {
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-      },
+  const response = await requestUrl({
+    url: `${FISH_API_URL}/model/${encodeURIComponent(voiceId)}`,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
     },
-  );
+    throw: false,
+  });
 
   await validate200Fish(response);
-  return parseFishVoice(await response.json());
+  return parseFishVoice(response.json);
 }
 
-export async function validate200Fish(response: Response): Promise<void> {
+export async function validate200Fish(
+  response: Pick<RequestUrlResponse, "status" | "json">,
+): Promise<void> {
   if (response.status < 300) {
     return;
   }
 
   let errorMessage: ErrorMessage | undefined;
   try {
-    errorMessage = fishErrorMessage(await response.json(), response.status);
+    errorMessage = fishErrorMessage(response.json, response.status);
   } catch {
     errorMessage = undefined;
   }

--- a/src/models/registry.ts
+++ b/src/models/registry.ts
@@ -9,6 +9,7 @@ import { azureTextToSpeech } from "./azure";
 import { minimaxTextToSpeech } from "./minimax";
 import { inworldTextToSpeech } from "./inworld";
 import { pollyTextToSpeech } from "./polly";
+import { fishTextToSpeech } from "./fish";
 
 export const REGISTRY: Record<ModelProvider, TTSModel> = {
   openai: openAITextToSpeech,
@@ -18,6 +19,7 @@ export const REGISTRY: Record<ModelProvider, TTSModel> = {
   elevenlabs: elevenLabsTextToSpeech,
   azure: azureTextToSpeech,
   minimax: minimaxTextToSpeech,
+  fish: fishTextToSpeech,
   inworld: inworldTextToSpeech,
   polly: pollyTextToSpeech,
 };

--- a/src/player/TTSPluginSettings.ts
+++ b/src/player/TTSPluginSettings.ts
@@ -124,6 +124,7 @@ export interface MinimaxModelConfig {
 
 export type FishModel = "s1" | "s2-pro";
 export type FishVoiceSource = "my-voices" | "custom";
+export type FishSentencePause = "none" | "short" | "long";
 
 export interface FishModelConfig {
   /** the API key to use */
@@ -134,6 +135,8 @@ export interface FishModelConfig {
   fish_voiceSource: FishVoiceSource;
   /** the voice model ID to use as reference_id */
   fish_voiceId: string;
+  /** Fish Audio pause control to insert between sentences */
+  fish_sentencePause: FishSentencePause;
 }
 
 export interface PollyModelConfig {
@@ -239,6 +242,7 @@ export const DEFAULT_SETTINGS: TTSPluginSettings = {
   fish_model: "s2-pro",
   fish_voiceSource: "custom",
   fish_voiceId: "",
+  fish_sentencePause: "none",
 
   // inworld
   inworld_apiKey: "",

--- a/src/player/TTSPluginSettings.ts
+++ b/src/player/TTSPluginSettings.ts
@@ -23,6 +23,7 @@ export type TTSPluginSettings = {
   ElevenLabsModelConfig &
   AzureModelConfig &
   MinimaxModelConfig &
+  FishModelConfig &
   InworldModelConfig &
   PollyModelConfig);
 
@@ -121,6 +122,20 @@ export interface MinimaxModelConfig {
   minimax_useChinaEndpoint: boolean;
 }
 
+export type FishModel = "s1" | "s2-pro";
+export type FishVoiceSource = "my-voices" | "custom";
+
+export interface FishModelConfig {
+  /** the API key to use */
+  fish_apiKey: string;
+  /** the Fish Audio TTS model to use */
+  fish_model: FishModel;
+  /** whether to pick from account voices or enter an ID manually */
+  fish_voiceSource: FishVoiceSource;
+  /** the voice model ID to use as reference_id */
+  fish_voiceId: string;
+}
+
 export interface PollyModelConfig {
   /** AWS Access Key ID */
   polly_accessKeyId: string;
@@ -164,6 +179,7 @@ export const modelProviders = [
   "gemini",
   "hume",
   "minimax",
+  "fish",
   "inworld",
   "polly",
 ] as const;
@@ -217,6 +233,12 @@ export const DEFAULT_SETTINGS: TTSPluginSettings = {
   minimax_ttsModel: "speech-2.6-turbo",
   minimax_ttsVoice: "English_expressive_narrator",
   minimax_useChinaEndpoint: false,
+
+  // fish
+  fish_apiKey: "",
+  fish_model: "s2-pro",
+  fish_voiceSource: "custom",
+  fish_voiceId: "",
 
   // inworld
   inworld_apiKey: "",


### PR DESCRIPTION
## Summary

Adds Fish Audio as a first-class TTS provider.

- Adds Fish Audio settings with API key validation, model selection, and voice source selection.
- Supports manual custom voice model IDs via `reference_id`, including unlisted voices.
- Supports loading account voices from Fish Audio with `GET /model?self=true`.
- Adds Fish Audio TTS calls via JSON REST requests to `POST /v1/tts` without adding new dependencies.
- Adds focused unit tests and includes Fish Audio in the provider list/docs.

## Test Plan

- `pnpm run test`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`

Note: I do not have Fish Audio credentials for live API smoke testing, so this PR verifies request shape and error handling with unit tests but still needs one real credential smoke test in Obsidian before release.