### PR TITLE
Add PCM response format for OpenAI-compatible TTS

### DIFF
--- a/src/components/settings/providers/provider-openai-like.tsx
+++ b/src/components/settings/providers/provider-openai-like.tsx
@@ -8,6 +8,7 @@ import { OptionSelectSetting, TextInputSetting } from "../setting-components";
 const AUDIO_FORMAT_OPTIONS = [
   { label: "MP3", value: "mp3" },
   { label: "WAV", value: "wav" },
+  { label: "PCM", value: "pcm" },
 ] as const;
 
 export const OpenAICompatibleSettings = observer(

--- a/src/models/openai-like.test.ts
+++ b/src/models/openai-like.test.ts
@@ -64,5 +64,26 @@ describe("OpenAI-Like Model", () => {
         responseFormat: "wav",
       });
     });
+
+    it("should pass through pcm response format", () => {
+      const testSettings = {
+        ...DEFAULT_SETTINGS,
+        openaicompat_apiKey: "test-api-key",
+        openaicompat_apiBase: "https://custom-api.example.com",
+        openaicompat_ttsModel: "tts-1",
+        openaicompat_ttsVoice: "alloy",
+        openaicompat_responseFormat: "pcm" as const,
+      };
+
+      const options = openAILikeTextToSpeech.convertToOptions(testSettings);
+
+      expect(options).toEqual({
+        apiKey: "test-api-key",
+        apiUri: "https://custom-api.example.com",
+        model: "tts-1",
+        voice: "alloy",
+        responseFormat: "pcm",
+      });
+    });
   });
 });

--- a/src/models/openai.ts
+++ b/src/models/openai.ts
@@ -99,7 +99,9 @@ export async function openAICompatCallTextToSpeech(
   settings: TTSPluginSettings,
   context: AudioTextContext = {},
 ): Promise<AudioData> {
-  const responseFormat = (options.responseFormat || "mp3") as MediaFormat;
+  const responseFormat = String(
+    options.responseFormat || "mp3",
+  ).toLowerCase() as MediaFormat;
 
   const response = await fetch(
     (options.apiUri || OPENAI_API_URL) + "/v1/audio/speech",


### PR DESCRIPTION
## Summary

Adds PCM as an available response format for the OpenAI Compatible provider.

Some OpenAI-compatible TTS backends/models, such as Gemini TTS through OpenRouter, require `response_format="pcm"` and reject `mp3`.

## Changes

- Adds `PCM` to the OpenAI Compatible audio format selector.
- Normalizes the OpenAI-compatible response format to lowercase before sending it to the API.
- Adds test coverage for passing through `pcm` response format.

## Testing

- Ran `pnpm run build`
- Ran `pnpm exec vitest run src/models/openai-like.test.ts`

Note: `pnpm run test` currently has one unrelated failing test in `src/components/TTSPluginSettingsTab.test.tsx` due to the existing `TooltipSpan` mock issue.