### PR TITLE
add setting to hide the editor action button

### DIFF
--- a/src/components/TTSSettingsTabComponent.tsx
+++ b/src/components/TTSSettingsTabComponent.tsx
@@ -76,6 +76,7 @@ export const TTSSettingsTabComponent: React.FC<{
 
       <SettingSection title="User Interface">
         <PlayerDisplayMode store={store} />
+        <EditorActionButtonToggle store={store} />
       </SettingSection>
 
       <SettingSection title="Storage">
@@ -187,6 +188,7 @@ function describeMode(mode: PlayerViewMode): string {
       return "Never show";
   }
 }
+
 const PlayerDisplayMode: React.FC<{
   store: TTSPluginSettingsStore;
 }> = observer(({ store }) => {
@@ -220,6 +222,33 @@ const PlayerDisplayMode: React.FC<{
             </option>
           ))}
         </select>
+      </div>
+    </div>
+  );
+});
+
+const EditorActionButtonToggle: React.FC<{
+  store: TTSPluginSettingsStore;
+}> = observer(({ store }) => {
+  return (
+    <div className="setting-item">
+      <div className="setting-item-info">
+        <div className="setting-item-name">Show Editor Action Button</div>
+        <div className="setting-item-description">
+          Show the Aloud play button in the editor header actions.
+        </div>
+      </div>
+      <div className="setting-item-control">
+        <div
+          className={`checkbox-container${store.settings.showEditorActionButton ? " is-enabled" : ""}`}
+          onClick={() =>
+            store.updateSettings({
+              showEditorActionButton: !store.settings.showEditorActionButton,
+            })
+          }
+        >
+          <input type="checkbox" tabIndex={0} />
+        </div>
       </div>
     </div>
   );

--- a/src/obsidian/TTSEditorAction.ts
+++ b/src/obsidian/TTSEditorAction.ts
@@ -52,7 +52,9 @@ export class TTSEditorAction {
     // Add to newly opened leaves
     this.plugin.registerEvent(
       this.plugin.app.workspace.on("active-leaf-change", (leaf) => {
-        this.addToLeaf(leaf);
+        if (this.settings.settings.showEditorActionButton) {
+          this.addToLeaf(leaf);
+        }
         this.pruneLeafStates();
       }),
     );
@@ -63,10 +65,21 @@ export class TTSEditorAction {
       }),
     );
 
-    // Add to all existing leaves
-    this.plugin.app.workspace.iterateAllLeaves((leaf) => {
-      this.addToLeaf(leaf);
+    // React to setting changes
+    const settingDisposer = autorun(() => {
+      const show = this.settings.settings.showEditorActionButton;
+      if (show) {
+        this.plugin.app.workspace.iterateAllLeaves((leaf) => {
+          this.addToLeaf(leaf);
+        });
+      } else {
+        this.removeAllButtons();
+      }
     });
+    this.plugin.register(() => settingDisposer());
+
+    // Add to all existing leaves (autorun above handles the initial add,
+    // but we still need the event handlers registered first)
   }
 
   /**
@@ -80,6 +93,17 @@ export class TTSEditorAction {
       state.root.unmount();
     }
     this.leafStates.clear();
+  }
+
+  private removeAllButtons(): void {
+    this.closeMenu();
+    for (const [leaf, state] of this.leafStates) {
+      this.disposeLeafState(leaf, state);
+    }
+    // Remove any action buttons that aren't tracked in leafStates (desktop)
+    document
+      .querySelectorAll(`[${EDITOR_ACTION_ATTR}="1"]`)
+      .forEach((el) => el.remove());
   }
 
   private addToLeaf(leaf: WorkspaceLeaf | null): void {

--- a/src/player/TTSPluginSettings.ts
+++ b/src/player/TTSPluginSettings.ts
@@ -12,6 +12,7 @@ export type TTSPluginSettings = {
   cacheType: "local" | "vault";
   cacheDurationMillis: number;
   showPlayerView: PlayerViewMode;
+  showEditorActionButton: boolean;
   autoScrollPlayerView: boolean;
   version: number;
   audioFolder: string;
@@ -175,6 +176,7 @@ export const DEFAULT_SETTINGS: TTSPluginSettings = {
   cacheDurationMillis: 1000 * 60 * 60 * 24 * 7, // 7 days
   cacheType: "local",
   showPlayerView: "always-mobile",
+  showEditorActionButton: true,
   autoScrollPlayerView: true,
   // gemini
   gemini_apiKey: "",


### PR DESCRIPTION
New toggle in settings: **Show Editor Action Button**. Obsidian doesn't expose a way to hide buttons that plugins add via `view.addAction()`, and tools like Commander can't reach them either. So the plugin needs to provide the toggle itself.

Closes #140

<img width="554" height="256" alt="image" src="https://github.com/user-attachments/assets/7480341e-29ec-4014-9ca2-e09f25abda67" />
