### PR TITLE
Convert LaTeX math to speakable text before TTS

### DIFF
--- a/src/util/cleanMarkdown.test.ts
+++ b/src/util/cleanMarkdown.test.ts
@@ -162,8 +162,7 @@ Just some text with dashes`;
   });
 
   it("should convert inline math to speakable text", () => {
-    const md =
-      "Starting with the constraint $6{x}_{1} + 4{x}_{2} \\leq {24}$";
+    const md = "Starting with the constraint $6{x}_{1} + 4{x}_{2} \\leq {24}$";
     const cleaned = cleanMarkup(md);
     expect(cleaned).toEqual(
       "Starting with the constraint 6x sub 1 + 4x sub 2 less than or equal to 24",

--- a/src/util/cleanMarkdown.test.ts
+++ b/src/util/cleanMarkdown.test.ts
@@ -161,70 +161,129 @@ Just some text with dashes`;
     );
   });
 
-  it("should convert inline math to speakable text", () => {
-    const md = "Starting with the constraint $6{x}_{1} + 4{x}_{2} \\leq {24}$";
-    const cleaned = cleanMarkup(md);
-    expect(cleaned).toEqual(
-      "Starting with the constraint 6x sub 1 + 4x sub 2 less than or equal to 24",
+  describe("LaTeX math", () => {
+    it("should convert the issue example to speakable text", () => {
+      const md =
+        "Starting with the constraint $6{x}_{1} + 4{x}_{2} \\leq {24}$";
+      expect(cleanMarkup(md)).toEqual(
+        "Starting with the constraint 6x sub 1 + 4x sub 2 less than or equal to 24",
+      );
+    });
+
+    it("should handle display math blocks", () => {
+      expect(
+        cleanMarkup("Consider:\n$$\\frac{a}{b} + \\sqrt{c}$$\nwhich is neat."),
+      ).toEqual("Consider:\na over b + square root of c\nwhich is neat.");
+    });
+
+    it("should handle display math on its own line", () => {
+      expect(cleanMarkup("Result:\n$$E = mc^{2}$$\nis famous.")).toEqual(
+        "Result:\nE = mc to the 2\nis famous.",
+      );
+    });
+
+    it("should handle multiple inline equations on the same line", () => {
+      expect(cleanMarkup("$a \\leq b$ and $c \\geq d$")).toEqual(
+        "a less than or equal to b and c greater than or equal to d",
+      );
+      expect(cleanMarkup("$x^{2}$ plus $y^{2}$ equals $z^{2}$")).toEqual(
+        "x to the 2 plus y to the 2 equals z to the 2",
+      );
+    });
+
+    it("should drop unknown LaTeX commands gracefully", () => {
+      expect(cleanMarkup("$\\mathrm{kg} \\cdot \\mathrm{m}$")).toEqual(
+        "kg times m",
+      );
+    });
+
+    // Structural commands with brace-delimited arguments
+    it.each([
+      ["\\frac{a}{b}", "a over b"],
+      ["\\frac{x + 1}{y - 2}", "x + 1 over y - 2"],
+      ["\\sqrt{16}", "square root of 16"],
+      ["\\sqrt[3]{8}", "3th root of 8"],
+    ])("structural: $%s → %s", (latex, expected) => {
+      expect(cleanMarkup(`$${latex}$`)).toEqual(expected);
+    });
+
+    // Command → word mappings
+    it.each([
+      ["\\leq", "less than or equal to"],
+      ["\\geq", "greater than or equal to"],
+      ["\\neq", "not equal to"],
+      ["\\approx", "approximately"],
+      ["\\times", "times"],
+      ["\\cdot", "times"],
+      ["\\div", "divided by"],
+      ["\\pm", "plus or minus"],
+      ["\\infty", "infinity"],
+      ["\\in", "in"],
+      ["\\forall", "for all"],
+      ["\\exists", "there exists"],
+      ["\\Rightarrow", "implies"],
+      ["\\iff", "if and only if"],
+      ["\\sum", "sum of"],
+      ["\\int", "integral of"],
+      ["\\sin", "sin"],
+      ["\\cos", "cos"],
+    ])("command: $x %s y$ maps %s", (cmd, speech) => {
+      expect(cleanMarkup(`$x ${cmd} y$`)).toEqual(`x ${speech} y`);
+    });
+
+    // Greek letters: backslash stripped, TTS pronounces the word
+    it.each(["alpha", "beta", "gamma", "delta", "pi", "omega", "Sigma"])(
+      "greek: $\\%s$ → %s",
+      (letter) => {
+        expect(cleanMarkup(`$\\${letter}$`)).toEqual(letter);
+      },
     );
+
+    // Superscripts and subscripts
+    it.each([
+      ["x^{2}", "x to the 2"],
+      ["x^2", "x to the 2"],
+      ["x_{i}", "x sub i"],
+      ["x_i", "x sub i"],
+      ["x^{2} + y^3 + z_{i}", "x to the 2 + y to the 3 + z sub i"],
+    ])("sub/superscript: $%s$ → %s", (latex, expected) => {
+      expect(cleanMarkup(`$${latex}$`)).toEqual(expected);
+    });
+
+    // Single variables in math mode
+    it.each([
+      ["$n$", "n"],
+      ["$x$", "x"],
+      ["$A$", "A"],
+    ])("single variable: %s → %s", (md, expected) => {
+      expect(cleanMarkup(md)).toEqual(expected);
+    });
+
+    it("should handle mixed variables and equations", () => {
+      expect(cleanMarkup("If $n$ is large and $m \\leq n$, then")).toEqual(
+        "If n is large and m less than or equal to n, then",
+      );
+    });
   });
 
-  it("should convert display math to speakable text", () => {
-    const md = "Consider:\n$$\\frac{a}{b} + \\sqrt{c}$$\nwhich is neat.";
-    const cleaned = cleanMarkup(md);
-    expect(cleaned).toEqual(
-      "Consider:\na over b + square root of c\nwhich is neat.",
-    );
-  });
-
-  it("should handle Greek letters in math", () => {
-    const md = "$\\alpha + \\beta = \\gamma$";
-    const cleaned = cleanMarkup(md);
-    expect(cleaned).toEqual("alpha + beta = gamma");
-  });
-
-  it("should handle superscripts and subscripts", () => {
-    const md = "$x^{2} + y^3 + z_{i}$";
-    const cleaned = cleanMarkup(md);
-    expect(cleaned).toEqual("x to the 2 + y to the 3 + z sub i");
-  });
-
-  it("should handle \\frac with nested content", () => {
-    const md = "$\\frac{x + 1}{y - 2}$";
-    const cleaned = cleanMarkup(md);
-    expect(cleaned).toEqual("x + 1 over y - 2");
-  });
-
-  it("should handle comparison operators", () => {
-    const md = "$a \\geq b$ and $c \\neq d$";
-    const cleaned = cleanMarkup(md);
-    expect(cleaned).toEqual(
-      "a greater than or equal to b and c not equal to d",
-    );
-  });
-
-  it("should handle sum/integral notation", () => {
-    const md = "$\\sum_{i=1}^{n} x_i$";
-    const cleaned = cleanMarkup(md);
-    expect(cleaned).toEqual("sum of sub i=1 to the n x sub i");
-  });
-
-  it("should drop unknown LaTeX commands gracefully", () => {
-    const md = "$\\mathrm{kg} \\cdot \\mathrm{m}$";
-    const cleaned = cleanMarkup(md);
-    expect(cleaned).toEqual("kg times m");
-  });
-
-  it("should not treat currency dollar signs as math", () => {
-    const md = "The price is $5 and the cost is $10.";
-    const cleaned = cleanMarkup(md);
-    expect(cleaned).toEqual("The price is $5 and the cost is $10.");
-  });
-
-  it("should handle display math blocks on their own lines", () => {
-    const md = "Result:\n$$E = mc^{2}$$\nis famous.";
-    const cleaned = cleanMarkup(md);
-    expect(cleaned).toEqual("Result:\nE = mc to the 2\nis famous.");
+  describe("dollar sign preservation", () => {
+    // Currency and other non-math uses of $ should not be mangled
+    it.each([
+      ["single currency", "The price is $5.", "The price is $5."],
+      ["two currencies", "costs $5 and $10", "costs $5 and $10"],
+      [
+        "multiple currencies in prose",
+        "She earned $500, saved $200, and spent $100.",
+        "She earned $500, saved $200, and spent $100.",
+      ],
+      [
+        "currency range",
+        "Costs range from $10 to $50 per unit.",
+        "Costs range from $10 to $50 per unit.",
+      ],
+    ])("%s: preserved", (_label, md, expected) => {
+      expect(cleanMarkup(md)).toEqual(expected);
+    });
   });
 
   it("should handle tables by removing markup and preserving content", () => {

--- a/src/util/cleanMarkdown.test.ts
+++ b/src/util/cleanMarkdown.test.ts
@@ -161,6 +161,73 @@ Just some text with dashes`;
     );
   });
 
+  it("should convert inline math to speakable text", () => {
+    const md =
+      "Starting with the constraint $6{x}_{1} + 4{x}_{2} \\leq {24}$";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual(
+      "Starting with the constraint 6x sub 1 + 4x sub 2 less than or equal to 24",
+    );
+  });
+
+  it("should convert display math to speakable text", () => {
+    const md = "Consider:\n$$\\frac{a}{b} + \\sqrt{c}$$\nwhich is neat.";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual(
+      "Consider:\na over b + square root of c\nwhich is neat.",
+    );
+  });
+
+  it("should handle Greek letters in math", () => {
+    const md = "$\\alpha + \\beta = \\gamma$";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual("alpha + beta = gamma");
+  });
+
+  it("should handle superscripts and subscripts", () => {
+    const md = "$x^{2} + y^3 + z_{i}$";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual("x to the 2 + y to the 3 + z sub i");
+  });
+
+  it("should handle \\frac with nested content", () => {
+    const md = "$\\frac{x + 1}{y - 2}$";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual("x + 1 over y - 2");
+  });
+
+  it("should handle comparison operators", () => {
+    const md = "$a \\geq b$ and $c \\neq d$";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual(
+      "a greater than or equal to b and c not equal to d",
+    );
+  });
+
+  it("should handle sum/integral notation", () => {
+    const md = "$\\sum_{i=1}^{n} x_i$";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual("sum of sub i=1 to the n x sub i");
+  });
+
+  it("should drop unknown LaTeX commands gracefully", () => {
+    const md = "$\\mathrm{kg} \\cdot \\mathrm{m}$";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual("kg times m");
+  });
+
+  it("should not treat currency dollar signs as math", () => {
+    const md = "The price is $5 and the cost is $10.";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual("The price is $5 and the cost is $10.");
+  });
+
+  it("should handle display math blocks on their own lines", () => {
+    const md = "Result:\n$$E = mc^{2}$$\nis famous.";
+    const cleaned = cleanMarkup(md);
+    expect(cleaned).toEqual("Result:\nE = mc to the 2\nis famous.");
+  });
+
   it("should handle tables by removing markup and preserving content", () => {
     const tableText = `| Column 1 | Column 2 | Column 3 |
 |----------|----------|----------|

--- a/src/util/cleanMarkdown.ts
+++ b/src/util/cleanMarkdown.ts
@@ -132,9 +132,8 @@ function removeFrontMatter(md: string): string {
   return md;
 }
 
-/** Maps of LaTeX commands to speakable text */
+/** LaTeX command → speakable text. Looked up with word-boundary matching. */
 const LATEX_COMMANDS: Record<string, string> = {
-  // Relations
   "\\leq": "less than or equal to",
   "\\le": "less than or equal to",
   "\\geq": "greater than or equal to",
@@ -147,17 +146,14 @@ const LATEX_COMMANDS: Record<string, string> = {
   "\\propto": "proportional to",
   "\\ll": "much less than",
   "\\gg": "much greater than",
-  // Operators
   "\\times": "times",
   "\\cdot": "times",
   "\\div": "divided by",
   "\\pm": "plus or minus",
   "\\mp": "minus or plus",
-  // Structures
   "\\infty": "infinity",
   "\\partial": "partial",
   "\\nabla": "del",
-  // Set/logic
   "\\in": "in",
   "\\notin": "not in",
   "\\subset": "subset of",
@@ -171,7 +167,6 @@ const LATEX_COMMANDS: Record<string, string> = {
   "\\neg": "not",
   "\\land": "and",
   "\\lor": "or",
-  // Arrows
   "\\to": "to",
   "\\rightarrow": "to",
   "\\leftarrow": "from",
@@ -179,7 +174,15 @@ const LATEX_COMMANDS: Record<string, string> = {
   "\\Leftarrow": "is implied by",
   "\\iff": "if and only if",
   "\\leftrightarrow": "if and only if",
-  // Misc
+  "\\sum": "sum of",
+  "\\prod": "product of",
+  "\\int": "integral of",
+  "\\lim": "limit of",
+  "\\log": "log",
+  "\\ln": "ln",
+  "\\sin": "sin",
+  "\\cos": "cos",
+  "\\tan": "tan",
   "\\ldots": "...",
   "\\cdots": "...",
   "\\dots": "...",
@@ -191,17 +194,13 @@ const LATEX_COMMANDS: Record<string, string> = {
   "\\\\": " ",
 };
 
-/**
- * Convert LaTeX math content to speakable text.
- * Handles fractions, roots, subscripts, superscripts, Greek letters,
- * and common commands. Unknown commands are dropped.
- */
+/** Convert LaTeX math content to speakable text. Unknown commands are dropped. */
 function cleanMath(math: string): string {
   let out = math;
 
+  // Structural commands that consume brace-delimited arguments
   // \frac{a}{b} → "a over b"
   out = out.replace(/\\frac\s*\{([^}]*)\}\s*\{([^}]*)\}/g, "$1 over $2");
-
   // \sqrt[n]{x} → "nth root of x", \sqrt{x} → "square root of x"
   out = out.replace(
     /\\sqrt\s*\[([^\]]*)\]\s*\{([^}]*)\}/g,
@@ -209,48 +208,29 @@ function cleanMath(math: string): string {
   );
   out = out.replace(/\\sqrt\s*\{([^}]*)\}/g, "square root of $1");
 
-  // \sum, \prod, \int with optional limits
-  out = out.replace(/\\sum/g, "sum of");
-  out = out.replace(/\\prod/g, "product of");
-  out = out.replace(/\\int/g, "integral of");
-  out = out.replace(/\\lim/g, "limit of");
-  out = out.replace(/\\log/g, "log");
-  out = out.replace(/\\ln/g, "ln");
-  out = out.replace(/\\sin/g, "sin");
-  out = out.replace(/\\cos/g, "cos");
-  out = out.replace(/\\tan/g, "tan");
-
-  // Replace known commands from the map (longest match first via iteration)
+  // Named commands from the map
   for (const [cmd, speech] of Object.entries(LATEX_COMMANDS)) {
-    // Escape backslash for regex, match the command not followed by a letter
     const escaped = cmd.replace(/\\/g, "\\\\");
     out = out.replace(new RegExp(escaped + "(?![a-zA-Z])", "g"), speech);
   }
 
-  // Greek letters: strip backslash, TTS handles the word
-  // (alpha, beta, gamma, delta, epsilon, theta, lambda, mu, sigma, omega, pi, phi, etc.)
+  // Greek letters: strip backslash, TTS pronounces the word
   out = out.replace(
     /\\(alpha|beta|gamma|delta|epsilon|varepsilon|zeta|eta|theta|vartheta|iota|kappa|lambda|mu|nu|xi|pi|rho|sigma|tau|upsilon|phi|varphi|chi|psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|Sigma|Upsilon|Phi|Psi|Omega)\b/g,
     "$1",
   );
 
-  // Drop remaining \commands (unknown ones)
+  // Drop remaining \commands and stray backslashes
   out = out.replace(/\\[a-zA-Z]+/g, "");
-  // Drop remaining backslashes
   out = out.replace(/\\/g, "");
 
-  // Superscript: x^{2} → "x to the 2", x^2 → "x to the 2"
+  // x^{2} → "x to the 2", x_i → "x sub i"
   out = out.replace(/\^\{([^}]*)\}/g, " to the $1");
   out = out.replace(/\^(\S)/g, " to the $1");
-
-  // Subscript: x_{i} → "x sub i", x_i → "x sub i"
   out = out.replace(/_\{([^}]*)\}/g, " sub $1");
   out = out.replace(/_(\S)/g, " sub $1");
 
-  // Remove remaining braces
   out = out.replace(/[{}]/g, "");
-
-  // Collapse whitespace
   out = out.replace(/\s+/g, " ").trim();
 
   return out;

--- a/src/util/cleanMarkdown.ts
+++ b/src/util/cleanMarkdown.ts
@@ -10,6 +10,15 @@ export default function cleanMarkup(md: string) {
   // First, remove frontmatter (must be done before other transformations)
   output = removeFrontMatter(output);
 
+  // Convert LaTeX math to speakable text (before other markdown processing
+  // since $ can interfere with emphasis regexes)
+  output = output.replace(/\$\$([\s\S]*?)\$\$/g, (_, m) => cleanMath(m));
+  // Inline math: must contain a backslash command or braces (not just plain text/numbers).
+  // This avoids matching currency like "$5" or "$10" while catching "$\leq$" or "${x}_{1}$".
+  output = output.replace(/\$([^$\n]+?)\$/g, (_, m) =>
+    /[\\{}^_]/.test(m) ? cleanMath(m) : "$" + m + "$",
+  );
+
   // Remove horizontal rules
   output = output.replace(/^\s*(\*{3,}|_{3,}|-{3,})\s*$/gm, "");
 
@@ -121,4 +130,128 @@ function removeFrontMatter(md: string): string {
 
   // No valid frontmatter found
   return md;
+}
+
+/** Maps of LaTeX commands to speakable text */
+const LATEX_COMMANDS: Record<string, string> = {
+  // Relations
+  "\\leq": "less than or equal to",
+  "\\le": "less than or equal to",
+  "\\geq": "greater than or equal to",
+  "\\ge": "greater than or equal to",
+  "\\neq": "not equal to",
+  "\\ne": "not equal to",
+  "\\approx": "approximately",
+  "\\sim": "approximately",
+  "\\equiv": "equivalent to",
+  "\\propto": "proportional to",
+  "\\ll": "much less than",
+  "\\gg": "much greater than",
+  // Operators
+  "\\times": "times",
+  "\\cdot": "times",
+  "\\div": "divided by",
+  "\\pm": "plus or minus",
+  "\\mp": "minus or plus",
+  // Structures
+  "\\infty": "infinity",
+  "\\partial": "partial",
+  "\\nabla": "del",
+  // Set/logic
+  "\\in": "in",
+  "\\notin": "not in",
+  "\\subset": "subset of",
+  "\\subseteq": "subset of",
+  "\\supset": "superset of",
+  "\\cup": "union",
+  "\\cap": "intersection",
+  "\\emptyset": "empty set",
+  "\\forall": "for all",
+  "\\exists": "there exists",
+  "\\neg": "not",
+  "\\land": "and",
+  "\\lor": "or",
+  // Arrows
+  "\\to": "to",
+  "\\rightarrow": "to",
+  "\\leftarrow": "from",
+  "\\Rightarrow": "implies",
+  "\\Leftarrow": "is implied by",
+  "\\iff": "if and only if",
+  "\\leftrightarrow": "if and only if",
+  // Misc
+  "\\ldots": "...",
+  "\\cdots": "...",
+  "\\dots": "...",
+  "\\quad": " ",
+  "\\qquad": " ",
+  "\\,": " ",
+  "\\;": " ",
+  "\\!": "",
+  "\\\\": " ",
+};
+
+/**
+ * Convert LaTeX math content to speakable text.
+ * Handles fractions, roots, subscripts, superscripts, Greek letters,
+ * and common commands. Unknown commands are dropped.
+ */
+function cleanMath(math: string): string {
+  let out = math;
+
+  // \frac{a}{b} → "a over b"
+  out = out.replace(/\\frac\s*\{([^}]*)\}\s*\{([^}]*)\}/g, "$1 over $2");
+
+  // \sqrt[n]{x} → "nth root of x", \sqrt{x} → "square root of x"
+  out = out.replace(
+    /\\sqrt\s*\[([^\]]*)\]\s*\{([^}]*)\}/g,
+    "$1th root of $2",
+  );
+  out = out.replace(/\\sqrt\s*\{([^}]*)\}/g, "square root of $1");
+
+  // \sum, \prod, \int with optional limits
+  out = out.replace(/\\sum/g, "sum of");
+  out = out.replace(/\\prod/g, "product of");
+  out = out.replace(/\\int/g, "integral of");
+  out = out.replace(/\\lim/g, "limit of");
+  out = out.replace(/\\log/g, "log");
+  out = out.replace(/\\ln/g, "ln");
+  out = out.replace(/\\sin/g, "sin");
+  out = out.replace(/\\cos/g, "cos");
+  out = out.replace(/\\tan/g, "tan");
+
+  // Replace known commands from the map (longest match first via iteration)
+  for (const [cmd, speech] of Object.entries(LATEX_COMMANDS)) {
+    // Escape backslash for regex, match the command not followed by a letter
+    const escaped = cmd.replace(/\\/g, "\\\\");
+    out = out.replace(new RegExp(escaped + "(?![a-zA-Z])", "g"), speech);
+  }
+
+  // Greek letters: strip backslash, TTS handles the word
+  // (alpha, beta, gamma, delta, epsilon, theta, lambda, mu, sigma, omega, pi, phi, etc.)
+  out = out.replace(
+    /\\(alpha|beta|gamma|delta|epsilon|varepsilon|zeta|eta|theta|vartheta|iota|kappa|lambda|mu|nu|xi|pi|rho|sigma|tau|upsilon|phi|varphi|chi|psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|Sigma|Upsilon|Phi|Psi|Omega)\b/g,
+    "$1",
+  );
+
+  // Drop remaining \commands (unknown ones)
+  out = out.replace(/\\[a-zA-Z]+/g, "");
+  // Drop remaining backslashes
+  out = out.replace(/\\/g, "");
+
+  // Superscript: x^{2} → "x to the 2", x^2 → "x to the 2"
+  out = out.replace(/\^\{([^}]*)\}/g, " to the $1");
+  out = out.replace(/\^(\S)/g, " to the $1");
+
+  // Subscript: x_{i} → "x sub i", x_i → "x sub i"
+  out = out.replace(/_\{([^}]*)\}/g, " sub $1");
+  out = out.replace(/_(\S)/g, " sub $1");
+
+  // Remove remaining braces
+  out = out.replace(/[{}]/g, "");
+
+  // Collapse whitespace
+  out = out.replace(/\s+/g, " ").trim();
+
+  return out;
 }

--- a/src/util/cleanMarkdown.ts
+++ b/src/util/cleanMarkdown.ts
@@ -13,10 +13,11 @@ export default function cleanMarkup(md: string) {
   // Convert LaTeX math to speakable text (before other markdown processing
   // since $ can interfere with emphasis regexes)
   output = output.replace(/\$\$([\s\S]*?)\$\$/g, (_, m) => cleanMath(m));
-  // Inline math: must contain a backslash command or braces (not just plain text/numbers).
-  // This avoids matching currency like "$5" or "$10" while catching "$\leq$" or "${x}_{1}$".
+  // Inline math: either contains LaTeX syntax (\, {}, ^, _) or doesn't start
+  // with a digit. Currency like "$5" or "$10" always starts with a digit;
+  // math variables like "$n$" or "$x + y$" don't.
   output = output.replace(/\$([^$\n]+?)\$/g, (_, m) =>
-    /[\\{}^_]/.test(m) ? cleanMath(m) : "$" + m + "$",
+    /[\\{}^_]/.test(m) || !/^\d/.test(m.trim()) ? cleanMath(m) : "$" + m + "$",
   );
 
   // Remove horizontal rules

--- a/src/util/cleanMarkdown.ts
+++ b/src/util/cleanMarkdown.ts
@@ -202,10 +202,7 @@ function cleanMath(math: string): string {
   // \frac{a}{b} → "a over b"
   out = out.replace(/\\frac\s*\{([^}]*)\}\s*\{([^}]*)\}/g, "$1 over $2");
   // \sqrt[n]{x} → "nth root of x", \sqrt{x} → "square root of x"
-  out = out.replace(
-    /\\sqrt\s*\[([^\]]*)\]\s*\{([^}]*)\}/g,
-    "$1th root of $2",
-  );
+  out = out.replace(/\\sqrt\s*\[([^\]]*)\]\s*\{([^}]*)\}/g, "$1th root of $2");
   out = out.replace(/\\sqrt\s*\{([^}]*)\}/g, "square root of $1");
 
   // Named commands from the map


### PR DESCRIPTION
Math expressions (`$...$` and `$$...$$`) were passing through to TTS verbatim. The model reads `\leq` as "backslash leq" or just drops surrounding content, so `$6{x}_{1} + 4{x}_{2} \leq {24}$` comes out as roughly "six x one plus 4 x two backslash leq 24 dollar".

`cleanMarkdown.ts` now converts math to natural language before the TTS call. Operators map to words (`\leq` → "less than or equal to", `\frac{a}{b}` → "a over b", `\sqrt{x}` → "square root of x"), Greek letters get their backslash stripped (TTS already pronounces "alpha"), and unknown commands are dropped rather than read literally. Currency `$5` is preserved by only treating `$...$` as math when the content contains LaTeX syntax (`\`, `{}`, `^`, `_`).

Fixes #133