### PR TITLE
feat: add MiniMax speech 2.8 models

### DIFF
--- a/src/components/settings/providers/provider-minimax.tsx
+++ b/src/components/settings/providers/provider-minimax.tsx
@@ -70,6 +70,8 @@ export const MinimaxSettings = observer(
 );
 
 const MINIMAX_MODELS = [
+  { label: "speech-2.8-hd", value: "speech-2.8-hd" },
+  { label: "speech-2.8-turbo", value: "speech-2.8-turbo" },
   { label: "speech-2.6-hd", value: "speech-2.6-hd" },
   { label: "speech-2.6-turbo", value: "speech-2.6-turbo" },
   { label: "speech-02-hd", value: "speech-02-hd" },


### PR DESCRIPTION
Adds `speech-2.8-hd` and `speech-2.8-turbo` to the MiniMax model selector so users can choose the newer TTS models. Endpoint configuration stays unchanged.