### PR TITLE
Add Ko-fi funding link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ You can also configure a custom API endpoint if you have an OpenAI compatible AP
 ### Alternate TTS Models
 
 You can also run alternate models if you have an OpenAI‑compatible API server that exposes `/v1/audio/speech` (for example, `openedai-speech`). Configure the URL and API key in the plugin settings under “OpenAI Compatible (Advanced)”.
+
+### Support
+
+If you find this plugin useful, you can [support development on Ko-fi](https://ko-fi.com/adrianlyjak). Donations help cover API keys for testing provider integrations.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -35,7 +35,10 @@ export default defineConfig({
 				// Custom CSS for purple theme
 				'./src/styles/custom.css',
 			],
-			social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/adrianlyjak/obsidian-aloud-tts' }],
+			social: [
+				{ icon: 'github', label: 'GitHub', href: 'https://github.com/adrianlyjak/obsidian-aloud-tts' },
+				{ icon: 'heart', label: 'Support on Ko-fi', href: 'https://ko-fi.com/adrianlyjak' },
+			],
 			sidebar: [
 				{
 					label: 'Getting Started',

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -12,6 +12,9 @@ hero:
     - text: View on GitHub
       link: https://github.com/adrianlyjak/obsidian-aloud-tts
       icon: external
+    - text: Support on Ko-fi
+      link: https://ko-fi.com/adrianlyjak
+      icon: heart
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';

--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,6 @@
   "description": "Highlight and speak text from your notes. Converts text to speech in real-time with lifelike voices.",
   "author": "Adrian Lyjak",
   "authorUrl": "https://github.com/adrianlyjak",
+  "fundingUrl": "https://ko-fi.com/adrianlyjak",
   "isDesktopOnly": false
 }


### PR DESCRIPTION
Adds Ko-fi funding link (`https://ko-fi.com/adrianlyjak`) to the manifest, README, and docs site.

- **manifest.json** `fundingUrl` field — Obsidian renders this as a Donate button on the plugin settings page
- **README** support section at the bottom
- **Docs site** hero action button + social link in the nav bar