### PR TITLE
Limit OpenAI-compatible generation speed range

### DIFF
--- a/src/components/settings/providers/provider-openai-like.tsx
+++ b/src/components/settings/providers/provider-openai-like.tsx
@@ -47,8 +47,8 @@ export const OpenAICompatibleSettings = observer(
           store={store}
           provider="openaicompat"
           fieldName="openaicompat_generationSpeed"
-          min={0.5}
-          max={4}
+          min={0.3}
+          max={2.5}
           step={0.05}
           defaultValue={1}
           formatValue={(value) => `${value.toFixed(2)}x`}

--- a/src/models/openai-like.test.ts
+++ b/src/models/openai-like.test.ts
@@ -115,7 +115,7 @@ describe("OpenAI-Like Model", () => {
     it("should fall back to generation speed 1 for out-of-range values", () => {
       const testSettings = {
         ...DEFAULT_SETTINGS,
-        openaicompat_generationSpeed: 5,
+        openaicompat_generationSpeed: 3,
       };
 
       const options = openAILikeTextToSpeech.convertToOptions(testSettings);

--- a/src/models/openai-like.ts
+++ b/src/models/openai-like.ts
@@ -15,8 +15,8 @@ export const openAILikeTextToSpeech: TTSModel = {
       responseFormat: settings.openaicompat_responseFormat,
       generationSpeed:
         Number.isFinite(generationSpeed) &&
-        generationSpeed >= 0.5 &&
-        generationSpeed <= 4
+        generationSpeed >= 0.3 &&
+        generationSpeed <= 2.5
           ? generationSpeed
           : 1,
     };


### PR DESCRIPTION
## Summary

Small follow-up to the merged Generation Speed setting.

This adjusts the OpenAI Compatible generation speed slider to use a more practical range:

- Minimum: `0.30`
- Maximum: `2.50`
- Step: `0.05`

This allows values like `0.35`, `0.40`, `0.75`, `1.25`, etc., while avoiding very high values such as `4.00`.