### PR TITLE
Fix reactivity and cleanup regressions from monorepo refactor

### DIFF
--- a/packages/obsidian/src/TTSCodemirror.test.ts
+++ b/packages/obsidian/src/TTSCodemirror.test.ts
@@ -19,6 +19,7 @@ vi.mock("react-dom/client", () => ({
 vi.mock("@open-tts/ui", () => ({
   PlayerView: () => null,
   createDOM: vi.fn(() => document.createElement("div")),
+  destroyDOM: vi.fn(),
   createLoadingSpinnerExtension: vi.fn(() => []),
   createTTSHighlightExtension: vi.fn(() => []),
   ObsidianLoadingWidgetFactory: vi.fn(),

--- a/packages/obsidian/src/TTSCodemirror.ts
+++ b/packages/obsidian/src/TTSCodemirror.ts
@@ -5,6 +5,7 @@ import { createRoot } from "react-dom/client";
 import { AudioSink, AudioStore, TTSPluginSettingsStore } from "open-tts";
 import {
   createDOM,
+  destroyDOM,
   createLoadingSpinnerExtension,
   createTTSHighlightExtension,
   ObsidianLoadingWidgetFactory,
@@ -59,8 +60,9 @@ function playerPanel(
         player,
         settings,
         sink,
-        shouldShow: shouldShowPlayerView(editor, player, settings, obsidian),
-        isMobilePhone: isMobilePhone(obsidian),
+        shouldShow: () =>
+          shouldShowPlayerView(editor, player, settings, obsidian),
+        isMobilePhone: () => isMobilePhone(obsidian),
         audioElement: (sink as SinkWithElement).audioElement,
         onOpenSettings: () => obsidian.openSettings(),
         onPlaySelection: () => obsidian.playSelection(),
@@ -92,7 +94,10 @@ export function TTSCodeMirror(
   sink: AudioSink,
   obsidian: ObsidianBridge,
 ): Extension {
-  const loadingWidgetFactory = new ObsidianLoadingWidgetFactory(createDOM);
+  const loadingWidgetFactory = new ObsidianLoadingWidgetFactory(
+    createDOM,
+    destroyDOM,
+  );
 
   return [
     createTTSHighlightExtension(

--- a/packages/ui/src/codemirror/TTSLoadingExtension.ts
+++ b/packages/ui/src/codemirror/TTSLoadingExtension.ts
@@ -12,14 +12,22 @@ import {
 // Platform-specific widget factory interface
 export interface LoadingWidgetFactory {
   createWidget(filename: string): HTMLElement;
+  destroyWidget?(element: HTMLElement): void;
 }
 
 // Obsidian widget factory using existing createDOM
 export class ObsidianLoadingWidgetFactory implements LoadingWidgetFactory {
-  constructor(private createDOM: (props: { file: string }) => HTMLElement) {}
+  constructor(
+    private createDOM: (props: { file: string }) => HTMLElement,
+    private _destroyWidget?: (element: HTMLElement) => void,
+  ) {}
 
   createWidget(filename: string): HTMLElement {
     return this.createDOM({ file: filename });
+  }
+
+  destroyWidget(element: HTMLElement): void {
+    this._destroyWidget?.(element);
   }
 }
 
@@ -69,6 +77,8 @@ export class WebLoadingWidgetFactory implements LoadingWidgetFactory {
 }
 
 class LoadingSpinnerWidget extends WidgetType {
+  private element: HTMLElement | undefined;
+
   constructor(
     private filename: string,
     private widgetFactory: LoadingWidgetFactory,
@@ -77,7 +87,15 @@ class LoadingSpinnerWidget extends WidgetType {
   }
 
   toDOM() {
-    return this.widgetFactory.createWidget(this.filename);
+    this.element = this.widgetFactory.createWidget(this.filename);
+    return this.element;
+  }
+
+  destroy() {
+    if (this.element) {
+      this.widgetFactory.destroyWidget?.(this.element);
+      this.element = undefined;
+    }
   }
 
   ignoreEvent() {

--- a/packages/ui/src/components/DownloadProgress.tsx
+++ b/packages/ui/src/components/DownloadProgress.tsx
@@ -1,12 +1,23 @@
 import * as React from "react";
-import { createRoot } from "react-dom/client";
+import { createRoot, type Root } from "react-dom/client";
 import { Spinner } from "./IconButton";
+
+const roots = new WeakMap<HTMLElement, Root>();
 
 export const createDOM = ({ file }: { file: string }) => {
   const container = document.createElement("span");
   const root = createRoot(container);
+  roots.set(container, root);
   root.render(<DownloadProgress file={file} />);
   return container;
+};
+
+export const destroyDOM = (element: HTMLElement) => {
+  const root = roots.get(element);
+  if (root) {
+    root.unmount();
+    roots.delete(element);
+  }
 };
 
 export const DownloadProgress: React.FC<{ file: string }> = ({ file }) => {

--- a/packages/ui/src/components/PlayerView.tsx
+++ b/packages/ui/src/components/PlayerView.tsx
@@ -24,16 +24,19 @@ export const PlayerView = observer(
     player: AudioStore;
     settings: TTSPluginSettingsStore;
     sink: AudioSink;
-    shouldShow: boolean;
-    isMobilePhone: boolean;
+    shouldShow: boolean | (() => boolean);
+    isMobilePhone: boolean | (() => boolean);
     audioElement?: HTMLAudioElement;
     onOpenSettings: () => void;
     onPlaySelection: () => void;
   }): React.ReactNode => {
-    if (isMobilePhone) {
-      return null;
-    }
+    // Evaluate getters inside observer body so MobX tracks dependencies
+    const isMobile =
+      typeof isMobilePhone === "function" ? isMobilePhone() : isMobilePhone;
+    const visible =
+      typeof shouldShow === "function" ? shouldShow() : shouldShow;
 
+    // All hooks must be called unconditionally (Rules of Hooks)
     const actions = React.useMemo(
       () =>
         createTTSActions(player, settings, {
@@ -42,7 +45,7 @@ export const PlayerView = observer(
       [player, settings, onPlaySelection],
     );
 
-    if (!shouldShow) {
+    if (isMobile || !visible) {
       return null;
     }
     return (


### PR DESCRIPTION
`PlayerView` visibility was computed once at panel creation and passed as a static boolean prop. MobX couldn't track the underlying observables (`player.activeText`, `obsidian.activeEditor`, etc.) so the toolbar never appeared when playback started. Pass getter functions instead so the reads happen inside the observer body.

While fixing that, `useMemo` was sitting below a conditional early return for mobile, violating React's Rules of Hooks. Moved all hooks above the conditional returns.

Loading spinner widgets (`DownloadProgress`) created a React root via `createRoot` on every `toDOM()` call with no corresponding unmount. Long sessions accumulate orphaned roots. Added `destroyWidget` to the `LoadingWidgetFactory` interface so `LoadingSpinnerWidget.destroy()` can clean up.