### PR TITLE
Add OpenAI-compatible provider profiles

### DIFF
--- a/packages/open-tts/src/player/TTSPluginSettings.ts
+++ b/packages/open-tts/src/player/TTSPluginSettings.ts
@@ -73,6 +73,17 @@ export interface OpenAIModelConfig {
 /** Response formats supported by OpenAI-compatible TTS APIs */
 export type OpenAICompatResponseFormat = "mp3" | "wav" | "pcm";
 
+export interface OpenAICompatProfile {
+  id: string;
+  name: string;
+  apiKey: string;
+  apiBase: string;
+  ttsModel: string;
+  ttsVoice: string;
+  responseFormat: OpenAICompatResponseFormat;
+  generationSpeed: number;
+}
+
 export interface OpenAICompatModelConfig {
   /** the API key to use. Not required */
   openaicompat_apiKey: string;
@@ -86,6 +97,10 @@ export interface OpenAICompatModelConfig {
   openaicompat_responseFormat: OpenAICompatResponseFormat;
   /** the generation speed to request from compatible TTS APIs. Defaults to 1. */
   openaicompat_generationSpeed: number;
+  /** the active OpenAI-compatible profile id */
+  openaicompat_activeProfileId: string;
+  /** saved OpenAI-compatible endpoint profiles */
+  openaicompat_profiles: OpenAICompatProfile[];
 }
 
 export interface ElevenLabsModelConfig {
@@ -225,6 +240,8 @@ export const DEFAULT_SETTINGS: TTSPluginSettings = {
   openaicompat_ttsVoice: "",
   openaicompat_responseFormat: "mp3",
   openaicompat_generationSpeed: 1,
+  openaicompat_activeProfileId: "",
+  openaicompat_profiles: [],
   // elevenlabs
   elevenlabs_apiKey: "",
   elevenlabs_model: "eleven_multilingual_v2",

--- a/packages/ui/src/components/settings/providers/provider-openai-like.tsx
+++ b/packages/ui/src/components/settings/providers/provider-openai-like.tsx
@@ -15,10 +15,216 @@ const AUDIO_FORMAT_OPTIONS = [
   { label: "PCM", value: "pcm" },
 ] as const;
 
+type OpenAICompatProfile =
+  TTSPluginSettingsStore["settings"]["openaicompat_profiles"][number];
+
+function createProfileId() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `openaicompat-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function getCurrentOpenAICompatProfile(
+  store: TTSPluginSettingsStore,
+  id: string,
+  name: string,
+): OpenAICompatProfile {
+  return {
+    id,
+    name,
+    apiKey: store.settings.openaicompat_apiKey,
+    apiBase: store.settings.openaicompat_apiBase,
+    ttsModel: store.settings.openaicompat_ttsModel,
+    ttsVoice: store.settings.openaicompat_ttsVoice,
+    responseFormat: store.settings.openaicompat_responseFormat,
+    generationSpeed: store.settings.openaicompat_generationSpeed,
+  };
+}
+
+async function loadOpenAICompatProfile(
+  store: TTSPluginSettingsStore,
+  profile: OpenAICompatProfile,
+) {
+  await store.updateModelSpecificSettings("openaicompat", {
+    openaicompat_activeProfileId: profile.id,
+    openaicompat_apiKey: profile.apiKey,
+    openaicompat_apiBase: profile.apiBase,
+    openaicompat_ttsModel: profile.ttsModel,
+    openaicompat_ttsVoice: profile.ttsVoice,
+    openaicompat_responseFormat: profile.responseFormat,
+    openaicompat_generationSpeed: profile.generationSpeed,
+  });
+}
+
+const OpenAICompatibleProfilesComponent: React.FC<{
+  store: TTSPluginSettingsStore;
+}> = observer(({ store }) => {
+  const profiles = store.settings.openaicompat_profiles ?? [];
+  const activeProfile = profiles.find(
+    (profile) => profile.id === store.settings.openaicompat_activeProfileId,
+  );
+
+  const [profileName, setProfileName] = React.useState(
+    activeProfile?.name ?? "",
+  );
+
+  React.useEffect(() => {
+    setProfileName(activeProfile?.name ?? "");
+  }, [activeProfile?.id, activeProfile?.name]);
+
+  async function saveProfile() {
+    const name = profileName.trim() || activeProfile?.name || "Default";
+    const id = activeProfile?.id ?? createProfileId();
+    const updatedProfile = getCurrentOpenAICompatProfile(store, id, name);
+
+    const nextProfiles = activeProfile
+      ? profiles.map((profile) =>
+          profile.id === activeProfile.id ? updatedProfile : profile,
+        )
+      : [...profiles, updatedProfile];
+
+    await store.updateModelSpecificSettings("openaicompat", {
+      openaicompat_activeProfileId: id,
+      openaicompat_profiles: nextProfiles,
+    });
+  }
+
+  async function saveAsNewProfile() {
+    const name = profileName.trim() || "New profile";
+    const id = createProfileId();
+    const newProfile = getCurrentOpenAICompatProfile(store, id, name);
+
+    await store.updateModelSpecificSettings("openaicompat", {
+      openaicompat_activeProfileId: id,
+      openaicompat_profiles: [...profiles, newProfile],
+    });
+  }
+
+  async function deleteProfile() {
+    if (!activeProfile) {
+      return;
+    }
+
+    const nextProfiles = profiles.filter(
+      (profile) => profile.id !== activeProfile.id,
+    );
+
+    await store.updateModelSpecificSettings("openaicompat", {
+      openaicompat_activeProfileId: "",
+      openaicompat_profiles: nextProfiles,
+    });
+
+    setProfileName("");
+  }
+
+  return (
+    <>
+      <div className="setting-item">
+        <div className="setting-item-info">
+          <div className="setting-item-name">Profile</div>
+          <div className="setting-item-description">
+            Save and switch between multiple OpenAI-compatible API
+            configurations.
+          </div>
+        </div>
+        <div className="setting-item-control">
+          <select
+            value={store.settings.openaicompat_activeProfileId}
+            onChange={async (event) => {
+              const profile = profiles.find(
+                (item) => item.id === event.target.value,
+              );
+
+              if (profile) {
+                await loadOpenAICompatProfile(store, profile);
+              } else {
+                await store.updateModelSpecificSettings("openaicompat", {
+                  openaicompat_activeProfileId: "",
+                });
+              }
+            }}
+          >
+            <option value="">No profile selected</option>
+            {profiles.map((profile) => (
+              <option key={profile.id} value={profile.id}>
+                {profile.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="setting-item">
+        <div className="setting-item-info">
+          <div className="setting-item-name">Save Profile</div>
+          <div className="setting-item-description">
+            Optional. Create a saved profile only if you want to switch between
+            multiple OpenAI-compatible APIs.
+          </div>
+        </div>
+        <div className="setting-item-control">
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "8px",
+              alignItems: "stretch",
+              width: "100%",
+            }}
+          >
+            <input
+              type="text"
+              value={profileName}
+              placeholder="Example: Openrouter Kok"
+              onChange={(event) => setProfileName(event.target.value)}
+            />
+
+            <div
+              style={{
+                display: "flex",
+                gap: "8px",
+                flexWrap: "nowrap",
+                alignItems: "center",
+              }}
+            >
+              <button
+                type="button"
+                onClick={saveProfile}
+                style={{ whiteSpace: "nowrap" }}
+              >
+                Save
+              </button>
+              <button
+                type="button"
+                onClick={saveAsNewProfile}
+                style={{ whiteSpace: "nowrap" }}
+              >
+                Save as new
+              </button>
+              <button
+                type="button"
+                onClick={deleteProfile}
+                disabled={!activeProfile}
+                style={{ whiteSpace: "nowrap" }}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+});
+
 export const OpenAICompatibleSettings = observer(
   ({ store }: { store: TTSPluginSettingsStore }) => {
     return (
       <>
+        <OpenAICompatibleProfilesComponent store={store} />
+
         <ApiKeyComponent
           store={store}
           provider="openaicompat"


### PR DESCRIPTION
## Summary

This PR adds saved profiles for the OpenAI Compatible provider settings.

Currently, the OpenAI Compatible provider only stores one API URL, API key, model, voice, response format, and generation speed. This makes it cumbersome to switch between multiple compatible endpoints.

With this change, users can save and switch between multiple OpenAI-compatible API configurations.

## Changes

- Adds `openaicompat_profiles`
- Adds `openaicompat_activeProfileId`
- Adds a profile selector to the OpenAI Compatible settings
- Adds controls to save, save as new, and delete profiles
- Keeps the existing OpenAI-compatible TTS provider implementation unchanged

## Motivation

Some users may use multiple OpenAI-compatible TTS endpoints, for example:

- a local TTS proxy
- an OpenRouter-compatible endpoint
- another custom `/v1/audio/speech` server

Profiles make it easier to switch between these configurations without manually replacing the API URL, key, model, voice, format, and speed each time.

## Testing

- Ran `pnpm typecheck`
- Ran `pnpm build`
- Manually tested the settings UI in Obsidian