### PR TITLE
Add setting for exported audio placement

### DIFF
--- a/packages/obsidian/src/ObsidianBridge.ts
+++ b/packages/obsidian/src/ObsidianBridge.ts
@@ -106,6 +106,25 @@ export class ObsidianBridgeImpl implements ObsidianBridge {
       if (editor) {
         if (replaceSelection) {
           editor.replaceSelection(loadingReplacement);
+        } else if (this.settings.settings.insertExportedAudioBelowSelection) {
+          const from = editor.getCursor("from");
+          const to = editor.getCursor("to");
+          const selectionEndsAtStartOfNextLine =
+            to.ch === 0 && to.line > from.line;
+
+          const insertPos = selectionEndsAtStartOfNextLine
+            ? to
+            : {
+                line: to.line,
+                ch: editor.getLine(to.line).length,
+              };
+
+          const replacement = selectionEndsAtStartOfNextLine
+            ? loadingReplacement
+            : "\n" + loadingReplacement;
+
+          // insert below the line where the selection ends
+          editor.replaceRange(replacement, insertPos, insertPos);
         } else {
           // insert at the start of the selection
           editor.replaceRange(

--- a/packages/open-tts/src/player/TTSPluginSettings.ts
+++ b/packages/open-tts/src/player/TTSPluginSettings.ts
@@ -14,6 +14,7 @@ export type TTSPluginSettings = {
   cacheDurationMillis: number;
   showPlayerView: PlayerViewMode;
   showEditorActionButton: boolean;
+  insertExportedAudioBelowSelection: boolean;
   autoScrollPlayerView: boolean;
   version: number;
   audioFolder: string;
@@ -202,6 +203,7 @@ export const DEFAULT_SETTINGS: TTSPluginSettings = {
   cacheType: "local",
   showPlayerView: "always-mobile",
   showEditorActionButton: true,
+  insertExportedAudioBelowSelection: false,
   autoScrollPlayerView: true,
   // gemini
   gemini_apiKey: "",

--- a/packages/ui/src/components/TTSSettingsTabComponent.tsx
+++ b/packages/ui/src/components/TTSSettingsTabComponent.tsx
@@ -69,6 +69,7 @@ export const TTSSettingsTabComponent: React.FC<{
       <SettingSection title="User Interface">
         <PlayerDisplayMode store={store} />
         <EditorActionButtonToggle store={store} />
+        <ExportAudioPlacementToggle store={store} />
       </SettingSection>
 
       <SettingSection title="Storage">
@@ -237,6 +238,37 @@ const EditorActionButtonToggle: React.FC<{
           onClick={() =>
             store.updateSettings({
               showEditorActionButton: !store.settings.showEditorActionButton,
+            })
+          }
+        >
+          <input type="checkbox" tabIndex={0} />
+        </div>
+      </div>
+    </div>
+  );
+});
+
+const ExportAudioPlacementToggle: React.FC<{
+  store: TTSPluginSettingsStore;
+}> = observer(({ store }) => {
+  return (
+    <div className="setting-item">
+      <div className="setting-item-info">
+        <div className="setting-item-name">
+          Insert Exported Audio Below Selection
+        </div>
+        <div className="setting-item-description">
+          When exporting selected text to audio, insert the audio embed below
+          the selected text instead of above it.
+        </div>
+      </div>
+      <div className="setting-item-control">
+        <div
+          className={`checkbox-container${store.settings.insertExportedAudioBelowSelection ? " is-enabled" : ""}`}
+          onClick={() =>
+            store.updateSettings({
+              insertExportedAudioBelowSelection:
+                !store.settings.insertExportedAudioBelowSelection,
             })
           }
         >


### PR DESCRIPTION
Adds a new User Interface setting to control where exported audio embeds are inserted when exporting selected text.

- Keeps the current behavior by default: insert above the selected text.
- Adds a checkbox to insert exported audio below the selected line.

Tested:
- pnpm build
- Manual test in Obsidian using a local plugin junction.