### PR TITLE
Add 'Save document as audio' toolbar action with progress + cancellation

### DIFF
--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -13,6 +13,36 @@ export class Notice {
   constructor(message: string, timeout?: number) {}
 }
 
+// Mock Modal class
+export class Modal {
+  app: any;
+  titleEl: any = { setText: noop };
+  contentEl: any = {
+    empty: noop,
+    createEl: () => ({ setText: noop }),
+  };
+  constructor(app: any) {
+    this.app = app;
+  }
+  open() {}
+  close() {}
+  onOpen() {}
+  onClose() {}
+}
+
+// Mock Setting class
+export class Setting {
+  constructor(containerEl: any) {}
+  addButton(cb: (btn: any) => void) {
+    cb({
+      setButtonText: () => ({ onClick: () => ({ setCta: () => ({}) }) }),
+      setCta: () => ({ onClick: () => ({}) }),
+      onClick: () => ({}),
+    });
+    return this;
+  }
+}
+
 // Mock Editor class
 export class Editor {
   getCursor() {

--- a/packages/obsidian/src/ObsidianBridge.test.ts
+++ b/packages/obsidian/src/ObsidianBridge.test.ts
@@ -19,6 +19,8 @@ vi.mock("obsidian", () => ({
   Notice: vi.fn(),
   MarkdownView: vi.fn(),
   TFile: vi.fn(),
+  Modal: vi.fn(),
+  Setting: vi.fn(),
 }));
 
 describe("ObsidianBridge", () => {

--- a/packages/obsidian/src/ObsidianBridge.ts
+++ b/packages/obsidian/src/ObsidianBridge.ts
@@ -5,7 +5,9 @@ import {
   Editor,
   MarkdownFileInfo,
   MarkdownView,
+  Modal,
   Notice,
+  Setting,
   TFile,
 } from "obsidian";
 import * as React from "react";
@@ -82,6 +84,63 @@ export class ObsidianBridgeImpl implements ObsidianBridge {
     // docs show this... types do not https://docs.obsidian.md/Plugins/Getting+started/Mobile+development
     // @ts-expect-error
     return this.app.isMobile;
+  };
+
+  saveDocumentAudio: () => Promise<void> = async () => {
+    const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+    if (!view) {
+      new Notice("Open a note first to save its audio.");
+      return;
+    }
+    const text = view.editor.getValue();
+    if (!text.trim()) {
+      new Notice("No text in the current note to convert.");
+      return;
+    }
+    const baseName =
+      view.file?.basename?.replace(/[^a-zA-Z0-9_-]+/g, "-").slice(0, 60) ||
+      "aloud-document";
+    const hash = hashString(text, 32).toString(16).slice(0, 8);
+    const filename = `${baseName}-${hash}.mp3`;
+
+    const destination = this.settings.settings.audioExportDestination;
+    let mode: "vault" | "download" =
+      destination === "vault" ? "vault" : "download";
+    if (destination === "prompt") {
+      const choice = await openExportDestinationModal(this.app);
+      if (!choice) return;
+      mode = choice;
+    }
+
+    new Notice("Generating audio, this may take some time…");
+    let bytes: ArrayBuffer;
+    try {
+      bytes = await this.audio.exportAudio(text);
+    } catch (ex) {
+      if (ex instanceof DOMException && ex.name === "AbortError") {
+        new Notice("Audio export cancelled");
+        return;
+      }
+      console.error("Couldn't generate audio for document!", ex);
+      new Notice("Failed to generate audio");
+      return;
+    }
+
+    try {
+      if (mode === "vault") {
+        const folder = this.settings.settings.audioFolder;
+        const vaultPath = `${folder}/${filename}`;
+        await this.app.vault.adapter.mkdir(folder);
+        await this.app.vault.adapter.writeBinary(vaultPath, bytes);
+        new Notice(`Saved ${vaultPath}`);
+      } else {
+        triggerBrowserDownload(bytes, filename);
+        new Notice(`Downloaded ${filename}`);
+      }
+    } catch (ex) {
+      console.error("Couldn't save audio!", ex);
+      new Notice("Failed to save audio file");
+    }
   };
 
   exportAudio: (text: string, replaceSelection: boolean) => Promise<void> =
@@ -312,4 +371,69 @@ export function isObsidianBridgeSpecifics(
   bridge: TTSEditorBridge,
 ): bridge is TTSEditorBridge & ObsidianBridgeSpecifics {
   return (bridge as any).activeObsidianEditor !== undefined;
+}
+
+function triggerBrowserDownload(bytes: ArrayBuffer, filename: string): void {
+  const blob = new Blob([bytes], { type: "audio/mpeg" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  // Defer revocation to give the browser time to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+function openExportDestinationModal(
+  app: App,
+): Promise<"vault" | "download" | null> {
+  return new Promise((resolve) => {
+    const modal = new ExportDestinationModal(app, resolve);
+    modal.open();
+  });
+}
+
+class ExportDestinationModal extends Modal {
+  private resolved = false;
+  constructor(
+    app: App,
+    private onChoice: (choice: "vault" | "download" | null) => void,
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    this.titleEl.setText("Save audio file");
+    this.contentEl.createEl("p", {
+      text: "Where would you like to save the generated audio?",
+    });
+    new Setting(this.contentEl)
+      .addButton((btn) =>
+        btn.setButtonText("Vault folder").onClick(() => this.choose("vault")),
+      )
+      .addButton((btn) =>
+        btn
+          .setButtonText("Download")
+          .setCta()
+          .onClick(() => this.choose("download")),
+      )
+      .addButton((btn) =>
+        btn.setButtonText("Cancel").onClick(() => this.choose(null)),
+      );
+  }
+
+  onClose(): void {
+    if (!this.resolved) {
+      this.onChoice(null);
+    }
+    this.contentEl.empty();
+  }
+
+  private choose(choice: "vault" | "download" | null): void {
+    this.resolved = true;
+    this.onChoice(choice);
+    this.close();
+  }
 }

--- a/packages/obsidian/src/TTSCodemirror.ts
+++ b/packages/obsidian/src/TTSCodemirror.ts
@@ -66,6 +66,11 @@ function playerPanel(
         audioElement: (sink as SinkWithElement).audioElement,
         onOpenSettings: () => obsidian.openSettings(),
         onPlaySelection: () => obsidian.playSelection(),
+        onSaveDocumentAudio: () => {
+          obsidian.saveDocumentAudio().catch((ex) => {
+            console.error("Couldn't save document audio!", ex);
+          });
+        },
       }),
     }),
   );

--- a/packages/obsidian/src/TTSCodemirror.ts
+++ b/packages/obsidian/src/TTSCodemirror.ts
@@ -44,6 +44,14 @@ function shouldShowPlayerView(
   }
 }
 
+function getSelectedText(editor: EditorView): string {
+  const selection = editor.state.selection.main;
+  if (selection.from === selection.to) {
+    return "";
+  }
+  return editor.state.doc.sliceString(selection.from, selection.to);
+}
+
 function playerPanel(
   editor: EditorView,
   player: AudioStore,
@@ -66,6 +74,16 @@ function playerPanel(
         audioElement: (sink as SinkWithElement).audioElement,
         onOpenSettings: () => obsidian.openSettings(),
         onPlaySelection: () => obsidian.playSelection(),
+        onExportSelectionAudio: () => {
+          const text = getSelectedText(editor);
+          if (!text.trim()) {
+            return;
+          }
+          obsidian.exportAudio(text, false).catch((ex) => {
+            console.error("Couldn't export selection audio!", ex);
+          });
+        },
+        canExportSelectionAudio: () => !!getSelectedText(editor).trim(),
         onSaveDocumentAudio: () => {
           obsidian.saveDocumentAudio().catch((ex) => {
             console.error("Couldn't save document audio!", ex);

--- a/packages/obsidian/src/TTSPlugin.ts
+++ b/packages/obsidian/src/TTSPlugin.ts
@@ -94,6 +94,20 @@ export default class TTSPlugin extends Plugin {
       },
     });
     this.addCommand({
+      id: "save-document-audio",
+      name: "Save document as audio",
+      checkCallback: (checking) => {
+        const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+        const busy = !!this.player.exportProgress;
+        if (checking) {
+          return !!view && !busy;
+        }
+        this.bridge.saveDocumentAudio().catch((ex) => {
+          console.error("Couldn't save document audio!", ex);
+        });
+      },
+    });
+    this.addCommand({
       id: "play-clipboard",
       name: "Play from clipboard",
       editorCheckCallback: (checking, editor: Editor, view: MarkdownView) => {
@@ -288,8 +302,9 @@ function ProxiedTTSModel(settings: TTSPluginSettings): TTSModel {
       options: TTSModelOptions,
       settings: TTSPluginSettings,
       context?: AudioTextContext,
+      signal?: AbortSignal,
     ) => {
-      return getModel().call(text, options, settings, context);
+      return getModel().call(text, options, settings, context, signal);
     },
     validateConnection: (settings: TTSPluginSettings) => {
       return getModel().validateConnection(settings);

--- a/packages/obsidian/styles.css
+++ b/packages/obsidian/styles.css
@@ -118,6 +118,40 @@
   justify-content: center;
   align-items: center;
 }
+
+.tts-export-progress {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  gap: 4px;
+  padding: 0 0.25rem;
+  font-size: var(--font-ui-smaller);
+  color: var(--text-muted);
+}
+
+.tts-export-progress-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tts-export-progress-track {
+  display: block;
+  width: 100%;
+  height: 4px;
+  background-color: var(--background-modifier-border);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.tts-export-progress-fill {
+  display: block;
+  height: 100%;
+  background-color: var(--interactive-accent);
+  border-radius: 2px;
+  transition: width 0.2s ease;
+}
 .tts-audio-status-error-icon {
   display: inline-flex;
   padding-right: 0.33rem;

--- a/packages/obsidian/styles.css
+++ b/packages/obsidian/styles.css
@@ -25,10 +25,13 @@
 
 .tts-toolbar-player {
   display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  width: 100%;
   padding: 0 var(--size-4-3);
   height: 32px;
   gap: var(--size-4-2);
-  align-items: stretch;
+  align-items: center;
 }
 
 .tts-toolbar-player-button-group {
@@ -119,38 +122,116 @@
   align-items: center;
 }
 
-.tts-export-progress {
+.tts-export-status {
   display: flex;
-  flex-direction: column;
-  justify-content: center;
+  align-items: center;
+  justify-content: flex-end;
   width: 100%;
-  gap: 4px;
-  padding: 0 0.25rem;
+  min-width: 0;
+  height: 100%;
+  padding: 0 var(--size-2-2, 4px) 0 0.25rem;
   font-size: var(--font-ui-smaller);
-  color: var(--text-muted);
-}
-
-.tts-export-progress-label {
+  line-height: 1;
+  color: var(--text-faint, var(--text-muted));
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  text-align: right;
 }
 
-.tts-export-progress-track {
-  display: block;
+.tts-export-cancel-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 24px;
+  min-width: 54px;
+  padding: 0 var(--size-4-2, 8px);
+  border: 1px solid var(--background-modifier-border, transparent);
+  border-radius: var(--radius-s, 4px);
+  background: transparent;
+  color: var(--interactive-accent);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--font-ui-smaller);
+  font-weight: 500;
+  line-height: 1;
+}
+
+.tts-export-cancel-button:hover,
+.tts-export-cancel-button:focus-visible {
+  color: var(--interactive-accent-hover, var(--interactive-accent));
+  background: var(--background-modifier-hover, transparent);
+}
+
+.tts-export-cancel-button:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 1px;
+}
+
+.tts-toolbar-overflow {
+  display: inline-flex;
+  position: relative;
+  align-items: center;
+}
+
+.tts-toolbar-overflow-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  min-width: 220px;
+  padding: var(--size-2-2, 4px);
+  background: var(--background-primary, var(--bg-secondary, #252526));
+  border: 1px solid
+    var(--background-modifier-border, var(--border-primary, #3e3e42));
+  border-radius: var(--radius-s, 4px);
+  box-shadow: var(--shadow-s, 0 4px 14px rgba(0, 0, 0, 0.28));
+}
+
+.tts-toolbar-overflow-menu-align-right {
+  right: 0;
+}
+
+.tts-toolbar-overflow-menu-align-left {
+  left: 0;
+}
+
+.tts-toolbar-overflow-menu-item {
+  display: flex;
+  align-items: center;
   width: 100%;
-  height: 4px;
-  background-color: var(--background-modifier-border);
-  border-radius: 2px;
-  overflow: hidden;
+  min-height: 32px;
+  padding: 0 var(--size-4-2, 8px);
+  border: 0;
+  border-radius: var(--radius-s, 4px);
+  background: transparent;
+  color: var(--text-normal, var(--text-primary, #cccccc));
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
 }
 
-.tts-export-progress-fill {
-  display: block;
-  height: 100%;
-  background-color: var(--interactive-accent);
-  border-radius: 2px;
-  transition: width 0.2s ease;
+.tts-toolbar-overflow-menu-item:hover:not(:disabled),
+.tts-toolbar-overflow-menu-item:focus-visible:not(:disabled) {
+  background: var(--background-modifier-hover, var(--bg-tertiary, #2d2d30));
+  color: var(--text-normal, var(--text-primary, #cccccc));
+}
+
+.tts-toolbar-overflow-menu-item:focus-visible {
+  outline: 2px solid var(--interactive-accent, var(--accent-primary, #007acc));
+  outline-offset: -2px;
+}
+
+.tts-toolbar-overflow-menu-item:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.tts-toolbar-overflow-menu-item .menu-item-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .tts-audio-status-error-icon {
   display: inline-flex;

--- a/packages/open-tts/src/models/azure.ts
+++ b/packages/open-tts/src/models/azure.ts
@@ -59,6 +59,7 @@ export async function azureCallTextToSpeech(
   options: TTSModelOptions,
   settings: TTSPluginSettings,
   context: AudioTextContext = {},
+  signal?: AbortSignal,
 ): Promise<AudioData> {
   if (!options.voice) {
     throw new Error("Voice is required for Azure TTS");
@@ -80,6 +81,7 @@ export async function azureCallTextToSpeech(
       "User-Agent": "obsidian-aloud-tts",
     },
     body: ssmlBody,
+    signal,
   });
 
   await validate200Azure(response);

--- a/packages/open-tts/src/models/elevenlabs.ts
+++ b/packages/open-tts/src/models/elevenlabs.ts
@@ -53,6 +53,7 @@ export async function elevenLabsCallTextToSpeech(
   options: TTSModelOptions,
   settings: TTSPluginSettings,
   context: AudioTextContext = {},
+  signal?: AbortSignal,
 ): Promise<AudioData> {
   if (!options.voice) {
     throw new TTSErrorInfo("Voice is required for ElevenLabs TTS", {
@@ -109,6 +110,7 @@ export async function elevenLabsCallTextToSpeech(
         "Content-Type": "application/json",
       },
       body: JSON.stringify(requestBody),
+      signal,
     },
   );
 

--- a/packages/open-tts/src/models/fish.ts
+++ b/packages/open-tts/src/models/fish.ts
@@ -65,6 +65,7 @@ export async function fishCallTextToSpeech(
   options: TTSModelOptions,
   _settings: TTSPluginSettings,
   _context: AudioTextContext = {},
+  signal?: AbortSignal,
 ): Promise<AudioData> {
   if (!options.voice) {
     throw new TTSErrorInfo("Voice model ID is required for Fish Audio TTS", {
@@ -92,6 +93,7 @@ export async function fishCallTextToSpeech(
       mp3_bitrate: 128,
       normalize: sentencePause === "none",
     }),
+    signal,
   });
 
   await validate200Fish(response);

--- a/packages/open-tts/src/models/gemini.ts
+++ b/packages/open-tts/src/models/gemini.ts
@@ -139,11 +139,15 @@ export async function geminiCallTextToSpeech(
   options: TTSModelOptions,
   settings: TTSPluginSettings,
   context: AudioTextContext = {},
+  signal?: AbortSignal,
 ): Promise<AudioData> {
   const ai = new GoogleGenAI({ apiKey: options.apiKey });
   let response: GenerateContentResponse;
   try {
-    response = await ai.models.generateContent({
+    // The @google/genai SDK does not currently expose AbortSignal, so we race
+    // the SDK promise against the signal to free the caller on cancel. The
+    // underlying HTTPS request may continue in the background.
+    const generate = ai.models.generateContent({
       model: options.model,
       contents: formatMessages(options.instructions, context, text),
       config: {
@@ -155,7 +159,11 @@ export async function geminiCallTextToSpeech(
         },
       },
     });
+    response = signal ? await raceAbort(generate, signal) : await generate;
   } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw error;
+    }
     throw mapGenAIError(error);
   }
   const res = response.candidates?.[0]?.content?.parts?.[0];
@@ -175,6 +183,29 @@ export async function geminiCallTextToSpeech(
       bitDepth: 16,
     },
   };
+}
+
+function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(new DOMException("Aborted", "AbortError"));
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
 }
 
 function formatMessages(

--- a/packages/open-tts/src/models/hume.ts
+++ b/packages/open-tts/src/models/hume.ts
@@ -36,6 +36,7 @@ export async function humeCallTextToSpeech(
   options: TTSModelOptions,
   settings: TTSPluginSettings,
   context: AudioTextContext = {},
+  signal?: AbortSignal,
 ): Promise<AudioData> {
   // Construct the utterances array for the Hume API request
   const utterance: {
@@ -80,6 +81,7 @@ export async function humeCallTextToSpeech(
       num_generations: 1,
       split_utterances: true,
     }),
+    signal,
   });
   await validate200Hume(headers);
   const res = await headers.json();

--- a/packages/open-tts/src/models/inworld.ts
+++ b/packages/open-tts/src/models/inworld.ts
@@ -53,6 +53,7 @@ export async function inworldCallTextToSpeech(
   options: TTSModelOptions,
   settings: TTSPluginSettings,
   context: AudioTextContext = {},
+  signal?: AbortSignal,
 ): Promise<AudioData> {
   const response = await fetch(`${INWORLD_API_URL}/tts/v1/voice`, {
     method: "POST",
@@ -68,6 +69,7 @@ export async function inworldCallTextToSpeech(
         audioEncoding: "MP3",
       },
     }),
+    signal,
   });
 
   await validate200Inworld(response);

--- a/packages/open-tts/src/models/minimax.ts
+++ b/packages/open-tts/src/models/minimax.ts
@@ -123,6 +123,7 @@ export async function minimaxCallTextToSpeech(
   options: TTSModelOptions,
   settings: TTSPluginSettings,
   _context: AudioTextContext = {},
+  signal?: AbortSignal,
 ): Promise<AudioData> {
   const groupId = settings.minimax_groupId;
   const apiUrl = getMinimaxApiUrl(settings);
@@ -152,6 +153,7 @@ export async function minimaxCallTextToSpeech(
       },
       output_format: "hex",
     }),
+    signal,
   });
 
   const responseText = await response.text();

--- a/packages/open-tts/src/models/openai.ts
+++ b/packages/open-tts/src/models/openai.ts
@@ -55,6 +55,7 @@ export async function openAICallTextToSpeech(
   options: TTSModelOptions,
   settings: TTSPluginSettings,
   context: AudioTextContext = {},
+  signal?: AbortSignal,
 ): Promise<AudioData> {
   const canInstruct = supportsInstructions(options.model);
   let instructions = options.instructions;
@@ -82,6 +83,7 @@ export async function openAICallTextToSpeech(
         speed: 1.0,
         response_format: "mp3",
       }),
+      signal,
     },
   );
   await validate200OpenAI(headers);
@@ -98,6 +100,7 @@ export async function openAICompatCallTextToSpeech(
   options: TTSModelOptions,
   settings: TTSPluginSettings,
   context: AudioTextContext = {},
+  signal?: AbortSignal,
 ): Promise<AudioData> {
   const responseFormat = String(
     options.responseFormat || "mp3",
@@ -118,6 +121,7 @@ export async function openAICompatCallTextToSpeech(
         speed: options.generationSpeed ?? 1,
         response_format: responseFormat,
       }),
+      signal,
     },
   );
   await validate200OpenAI(response);

--- a/packages/open-tts/src/models/polly.ts
+++ b/packages/open-tts/src/models/polly.ts
@@ -96,6 +96,7 @@ export async function pollyCallTextToSpeech(
   options: TTSModelOptions,
   settings: TTSPluginSettings,
   _context: AudioTextContext = {},
+  signal?: AbortSignal,
 ): Promise<AudioData> {
   if (!settings.polly_voiceId) {
     throw new TTSErrorInfo("Voice is required for AWS Polly", {
@@ -135,6 +136,7 @@ export async function pollyCallTextToSpeech(
     method: "POST",
     headers: signed.headers,
     body: requestBody,
+    signal,
   });
 
   await validate200Polly(response);

--- a/packages/open-tts/src/models/tts-model.ts
+++ b/packages/open-tts/src/models/tts-model.ts
@@ -35,6 +35,7 @@ export interface TTSModel {
     options: TTSModelOptions,
     settings: TTSPluginSettings,
     context?: AudioTextContext,
+    signal?: AbortSignal,
   ): Promise<AudioData>;
 
   /** Returns an error message if the connection is not valid, otherwise undefined */

--- a/packages/open-tts/src/player/AudioStore.ts
+++ b/packages/open-tts/src/player/AudioStore.ts
@@ -11,11 +11,21 @@ import { splitTextForExport } from "../util/misc";
 import { concatenateMp3Buffers } from "../util/audioProcessing";
 // AudioData is returned from provider calls, but exportAudio concatenates raw bytes
 
+/** Progress of an in-flight export, reported per text chunk. */
+export interface ExportProgress {
+  /** Chunks generated so far. */
+  completed: number;
+  /** Total chunks for this export. */
+  total: number;
+}
+
 /** High level track changer interface */
 export interface AudioStore {
   // observables
   activeText: ActiveAudioText | null;
   autoScrollEnabled: boolean;
+  /** Non-null while `exportAudio` is running. */
+  exportProgress: ExportProgress | null;
 
   // switches the active track
   // returns a track ID
@@ -26,6 +36,9 @@ export interface AudioStore {
 
   /** exports an mp3 audio file. TODO make this better */
   exportAudio(text: string): Promise<ArrayBuffer>;
+
+  /** Aborts the currently-running `exportAudio` at the next chunk boundary. */
+  cancelExport(): void;
 
   /**
    * destroys this audio store. Further interaction
@@ -67,6 +80,8 @@ export function loadAudioStore({
 class AudioStoreImpl implements AudioStore {
   activeText: ActiveAudioText | null = null;
   autoScrollEnabled = true;
+  exportProgress: ExportProgress | null = null;
+  private exportAbortController: AbortController | null = null;
   private lastProgrammaticScroll = 0;
   system: AudioSystem;
 
@@ -77,7 +92,9 @@ class AudioStoreImpl implements AudioStore {
     mobx.makeObservable(this, {
       activeText: observable,
       autoScrollEnabled: observable,
+      exportProgress: observable.ref,
       closePlayer: action,
+      cancelExport: action,
       markProgrammaticScroll: action,
     });
 
@@ -88,42 +105,81 @@ class AudioStoreImpl implements AudioStore {
     return this.system.storage.getStorageSize();
   }
 
+  cancelExport(): void {
+    this.exportAbortController?.abort();
+  }
+
   async exportAudio(text: string): Promise<ArrayBuffer> {
     const options = this.system.ttsModel.convertToOptions(this.system.settings);
 
     // Get model's practical character limit (most models have 4000-4096 limit)
     const maxChunkSize = 4000; // Conservative limit to avoid hitting model limits
 
-    // If text is short enough, process directly
-    if (text.length <= maxChunkSize) {
-      const audio = await this.system.ttsModel.call(
-        text,
-        options,
-        this.system.settings,
-      );
-      // export remains mp3 for now; if not mp3, we could convert later
-      return audio.data;
-    }
+    const controller = new AbortController();
+    this.exportAbortController = controller;
+    const signal = controller.signal;
+    const setProgress = action(
+      "setExportProgress",
+      (progress: ExportProgress | null) => {
+        this.exportProgress = progress;
+      },
+    );
 
-    // Split text into chunks with context that respect sentence boundaries
-    const chunksWithContext = splitTextForExport(text, maxChunkSize, 2);
-    const decodedAudios: ArrayBuffer[] = [];
+    const throwIfAborted = () => {
+      if (signal.aborted) {
+        throw new DOMException("Export cancelled", "AbortError");
+      }
+    };
 
-    // Generate audio for each chunk
-    for (const chunk of chunksWithContext) {
-      if (chunk.text.trim()) {
+    try {
+      // If text is short enough, process directly
+      if (text.length <= maxChunkSize) {
+        setProgress({ completed: 0, total: 1 });
+        throwIfAborted();
+        const audio = await this.system.ttsModel.call(
+          text,
+          options,
+          this.system.settings,
+          undefined,
+          signal,
+        );
+        setProgress({ completed: 1, total: 1 });
+        // export remains mp3 for now; if not mp3, we could convert later
+        return audio.data;
+      }
+
+      // Split text into chunks with context that respect sentence boundaries
+      const chunksWithContext = splitTextForExport(text, maxChunkSize, 2);
+      const renderable = chunksWithContext.filter((c) => c.text.trim());
+      const decodedAudios: ArrayBuffer[] = [];
+      setProgress({ completed: 0, total: renderable.length });
+
+      // Generate audio for each chunk
+      for (const chunk of renderable) {
+        throwIfAborted();
         const audio = await this.system.ttsModel.call(
           chunk.text,
           options,
           this.system.settings,
           chunk.context,
+          signal,
         );
         decodedAudios.push(audio.data);
+        setProgress({
+          completed: decodedAudios.length,
+          total: renderable.length,
+        });
       }
-    }
 
-    // Concatenate all audio buffers into a single MP3
-    return await concatenateMp3Buffers(decodedAudios, this.system.audioSink);
+      throwIfAborted();
+      // Concatenate all audio buffers into a single MP3
+      return await concatenateMp3Buffers(decodedAudios, this.system.audioSink);
+    } finally {
+      if (this.exportAbortController === controller) {
+        this.exportAbortController = null;
+      }
+      setProgress(null);
+    }
   }
 
   _backgroundProcesses: { shutdown: () => void }[] = [];

--- a/packages/open-tts/src/player/TTSActions.test.ts
+++ b/packages/open-tts/src/player/TTSActions.test.ts
@@ -11,9 +11,11 @@ function createMockPlayer(): AudioStore {
   return {
     activeText: null,
     autoScrollEnabled: true,
+    exportProgress: null,
     startPlayer: vi.fn(),
     closePlayer: vi.fn(),
     exportAudio: vi.fn(),
+    cancelExport: vi.fn(),
     destroy: vi.fn(),
     clearStorage: vi.fn(),
     getStorageSize: vi.fn(),

--- a/packages/open-tts/src/player/TTSPluginSettings.ts
+++ b/packages/open-tts/src/player/TTSPluginSettings.ts
@@ -17,6 +17,7 @@ export type TTSPluginSettings = {
   autoScrollPlayerView: boolean;
   version: number;
   audioFolder: string;
+  audioExportDestination: AudioExportDestination;
 } & (GeminiModelConfig &
   HumeModelConfig &
   OpenAIModelConfig &
@@ -168,6 +169,16 @@ export function isPlayerViewMode(value: unknown): value is PlayerViewMode {
   return playViewModes.includes(value as PlayerViewMode);
 }
 
+export const audioExportDestinations = ["vault", "download", "prompt"] as const;
+
+export type AudioExportDestination = (typeof audioExportDestinations)[number];
+
+export function isAudioExportDestination(
+  value: unknown,
+): value is AudioExportDestination {
+  return audioExportDestinations.includes(value as AudioExportDestination);
+}
+
 export function voiceHash(options: TTSModelOptions): string {
   return hashStrings([
     [
@@ -265,6 +276,7 @@ export const DEFAULT_SETTINGS: TTSPluginSettings = {
 
   version: 2,
   audioFolder: "aloud",
+  audioExportDestination: "download",
 } as const;
 
 export interface TTSPluginSettingsStore {

--- a/packages/ui/src/codemirror/TTSCodeMirrorCore.ts
+++ b/packages/ui/src/codemirror/TTSCodeMirrorCore.ts
@@ -34,6 +34,10 @@ export interface TTSEditorBridge {
   destroy: () => void;
   isMobile: () => boolean;
   exportAudio: (text: string, replaceSelection?: boolean) => Promise<void>;
+  /** Export the entire active document as an audio file. Destination is
+   * controlled by the `audioExportDestination` setting (vault folder, OS
+   * download, or prompt). Does not modify the editor contents. */
+  saveDocumentAudio: () => Promise<void>;
 }
 
 export interface TTSAutoscrollRange {

--- a/packages/ui/src/components/IconButton.tsx
+++ b/packages/ui/src/components/IconButton.tsx
@@ -21,6 +21,8 @@ const iconMap: Record<string, LucideIcon> = {
   "rotate-cw": Icons.RotateCw,
   trash: Icons.Trash2,
   download: Icons.Download,
+  "more-horizontal": Icons.MoreHorizontal,
+  "more-vertical": Icons.MoreVertical,
   "external-link": Icons.ExternalLink,
   x: Icons.X,
   "step-forward": Icons.StepForward,

--- a/packages/ui/src/components/PlayerView.test.tsx
+++ b/packages/ui/src/components/PlayerView.test.tsx
@@ -1,18 +1,45 @@
 import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { runInAction } from "mobx";
 import React from "react";
 import { PlayerView } from "./PlayerView";
+import type { PlayerViewProps } from "./PlayerView";
 import {
   createTestAudioStore,
   createTestSettingsStore,
   FakeAudioSink,
 } from "./test-utils";
 
+type MockIconButtonProps = {
+  icon: string;
+  onClick: () => void;
+  tooltip?: string;
+  disabled?: boolean;
+  highlight?: boolean;
+};
+
 vi.mock("./IconButton", () => ({
-  IconButton: ({ children, onClick }: any) => (
-    <button onClick={onClick}>{children}</button>
+  IconButton: ({
+    icon,
+    onClick,
+    tooltip,
+    disabled,
+    highlight,
+  }: MockIconButtonProps) => (
+    <button
+      type="button"
+      aria-label={tooltip ?? icon}
+      data-icon={icon}
+      data-highlight={highlight ? "true" : "false"}
+      disabled={disabled}
+      onClick={disabled ? undefined : onClick}
+    >
+      {tooltip ?? icon}
+    </button>
   ),
-  IconSpan: ({ children }: any) => <span>{children}</span>,
+  IconSpan: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
   Spinner: () => <div data-testid="spinner">Loading...</div>,
 }));
 
@@ -22,25 +49,160 @@ vi.mock("./AudioVisualizer", () => ({
   ),
 }));
 
+async function renderPlayerView(
+  overrides: Partial<PlayerViewProps> = {},
+): Promise<{
+  player: PlayerViewProps["player"];
+  settings: PlayerViewProps["settings"];
+  sink: PlayerViewProps["sink"];
+}> {
+  const player = overrides.player ?? createTestAudioStore();
+  const settings = overrides.settings ?? (await createTestSettingsStore());
+  const sink = overrides.sink ?? new FakeAudioSink();
+  const props: PlayerViewProps = {
+    player,
+    settings,
+    sink,
+    shouldShow: true,
+    isMobilePhone: false,
+    onOpenSettings: vi.fn(),
+    onPlaySelection: vi.fn(),
+    ...overrides,
+  };
+
+  render(<PlayerView {...props} />);
+
+  return { player, settings, sink };
+}
+
 describe("PlayerView", () => {
   it("should render without crashing", async () => {
-    const mockAudioStore = createTestAudioStore();
-    const mockSettings = await createTestSettingsStore();
-    const mockSink = new FakeAudioSink();
+    await renderPlayerView();
 
-    render(
-      <PlayerView
-        player={mockAudioStore}
-        settings={mockSettings}
-        sink={mockSink}
-        shouldShow={true}
-        isMobilePhone={false}
-        onOpenSettings={vi.fn()}
-        onPlaySelection={vi.fn()}
-      />,
+    expect(document.body).toBeTruthy();
+  });
+
+  it("keeps document export out of the permanent toolbar", async () => {
+    await renderPlayerView({
+      onSaveDocumentAudio: vi.fn(),
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Save document as audio..." }),
+    ).toBeNull();
+    expect(document.querySelector('[data-icon="download"]')).toBeNull();
+    expect(screen.getByRole("button", { name: "More" })).toBeTruthy();
+  });
+
+  it("opens an overflow menu with export actions", async () => {
+    const exportSelection = vi.fn();
+    const saveDocument = vi.fn();
+    await renderPlayerView({
+      onExportSelectionAudio: exportSelection,
+      canExportSelectionAudio: true,
+      onSaveDocumentAudio: saveDocument,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+    expect(
+      (
+        screen.getByRole("menuitem", {
+          name: "Export selection as audio...",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+    expect(
+      (
+        screen.getByRole("menuitem", {
+          name: "Save document as audio...",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Save document as audio..." }),
     );
 
-    // Component renders conditionally, just verify no crash
-    expect(document.body).toBeTruthy();
+    expect(saveDocument).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("disables selection export when there is no selection", async () => {
+    await renderPlayerView({
+      onExportSelectionAudio: vi.fn(),
+      canExportSelectionAudio: false,
+      onSaveDocumentAudio: vi.fn(),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+    expect(
+      (
+        screen.getByRole("menuitem", {
+          name: "Export selection as audio...",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it("disables document export while export is running", async () => {
+    const player = createTestAudioStore();
+    runInAction(() => {
+      player.exportProgress = { completed: 0, total: 1 };
+    });
+
+    await renderPlayerView({
+      player,
+      onSaveDocumentAudio: vi.fn(),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+    expect(
+      (
+        screen.getByRole("menuitem", {
+          name: "Save document as audio...",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it("shows export progress and a cancel button even when the player is hidden", async () => {
+    const player = createTestAudioStore();
+    const cancelExport = vi.spyOn(player, "cancelExport");
+    runInAction(() => {
+      player.exportProgress = { completed: 0, total: 1 };
+    });
+
+    await renderPlayerView({
+      player,
+      shouldShow: false,
+    });
+
+    expect(screen.getByText("Saving document audio...")).toBeTruthy();
+    expect(screen.queryByText(/chunks/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Play selection" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "More" })).toBeNull();
+
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+
+    fireEvent.click(cancelButton);
+
+    expect(cancelExport).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows section progress without exposing chunks", async () => {
+    const player = createTestAudioStore();
+    runInAction(() => {
+      player.exportProgress = { completed: 0, total: 3 };
+    });
+
+    await renderPlayerView({
+      player,
+    });
+
+    expect(screen.getByText("Saving document audio... 1 of 3")).toBeTruthy();
+    expect(screen.queryByText(/chunks/)).toBeNull();
   });
 });

--- a/packages/ui/src/components/PlayerView.tsx
+++ b/packages/ui/src/components/PlayerView.tsx
@@ -20,6 +20,7 @@ export const PlayerView = observer(
     audioElement,
     onOpenSettings,
     onPlaySelection,
+    onSaveDocumentAudio,
   }: {
     player: AudioStore;
     settings: TTSPluginSettingsStore;
@@ -29,6 +30,7 @@ export const PlayerView = observer(
     audioElement?: HTMLAudioElement;
     onOpenSettings: () => void;
     onPlaySelection: () => void;
+    onSaveDocumentAudio?: () => void;
   }): React.ReactNode => {
     // Evaluate getters inside observer body so MobX tracks dependencies
     const isMobile =
@@ -56,6 +58,21 @@ export const PlayerView = observer(
             tooltip="Play selection"
             onClick={() => actions.playSelection()}
           />
+          {onSaveDocumentAudio &&
+            (player.exportProgress ? (
+              <IconButton
+                icon="square"
+                tooltip={formatExportTooltip(player.exportProgress)}
+                onClick={() => player.cancelExport()}
+                highlight
+              />
+            ) : (
+              <IconButton
+                icon="download"
+                tooltip="Save document as audio"
+                onClick={() => onSaveDocumentAudio()}
+              />
+            ))}
         </div>
         <div className="tts-toolbar-player-button-group">
           <IconButton
@@ -204,12 +221,52 @@ const EditPlaybackSpeedButton: React.FC<{
   );
 });
 
+function formatExportTooltip(progress: {
+  completed: number;
+  total: number;
+}): string {
+  if (!progress.total) {
+    return "Stop saving audio";
+  }
+  return `Stop saving audio (${progress.completed}/${progress.total} chunks)`;
+}
+
+const ExportProgressBar: React.FC<{
+  progress: { completed: number; total: number };
+}> = ({ progress }) => {
+  const pct = progress.total
+    ? Math.round((progress.completed / progress.total) * 100)
+    : 0;
+  return (
+    <span
+      className="tts-export-progress"
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={pct}
+    >
+      <span className="tts-export-progress-label">
+        Saving audio… {progress.completed}/{progress.total}
+      </span>
+      <span className="tts-export-progress-track">
+        <span
+          className="tts-export-progress-fill"
+          style={{ width: `${pct}%` }}
+        />
+      </span>
+    </span>
+  );
+};
+
 const AudioStatusInfoContents: React.FC<{
   audioElement?: HTMLAudioElement;
   player: AudioStore;
   settings: TTSPluginSettingsStore;
   onOpenSettings: () => void;
 }> = observer(({ audioElement, player, settings, onOpenSettings }) => {
+  if (player.exportProgress) {
+    return <ExportProgressBar progress={player.exportProgress} />;
+  }
   if (settings.apiKeyValid === false) {
     return (
       // Extra span container to absorb the align-items: stretch from the container

--- a/packages/ui/src/components/PlayerView.tsx
+++ b/packages/ui/src/components/PlayerView.tsx
@@ -6,9 +6,29 @@ import { AudioStore } from "open-tts";
 import { createTTSActions } from "open-tts";
 import { AudioVisualizer } from "./AudioVisualizer";
 import { IconButton, Spinner } from "./IconButton";
+import { ToolbarOverflowMenu } from "./ToolbarOverflowMenu";
+import type { ToolbarOverflowMenuItem } from "./ToolbarOverflowMenu";
 import { TTSErrorInfo } from "open-tts";
 import { useTooltip } from "../util/TooltipContext";
 import { AlertCircle } from "lucide-react";
+
+type Availability = boolean | (() => boolean);
+type ExportProgress = { completed: number; total: number };
+
+export interface PlayerViewProps {
+  player: AudioStore;
+  settings: TTSPluginSettingsStore;
+  sink: AudioSink;
+  shouldShow: boolean | (() => boolean);
+  isMobilePhone: boolean | (() => boolean);
+  audioElement?: HTMLAudioElement;
+  onOpenSettings: () => void;
+  onPlaySelection: () => void;
+  onExportSelectionAudio?: () => void;
+  canExportSelectionAudio?: Availability;
+  onSaveDocumentAudio?: () => void;
+  canSaveDocumentAudio?: Availability;
+}
 
 export const PlayerView = observer(
   ({
@@ -20,18 +40,11 @@ export const PlayerView = observer(
     audioElement,
     onOpenSettings,
     onPlaySelection,
+    onExportSelectionAudio,
+    canExportSelectionAudio,
     onSaveDocumentAudio,
-  }: {
-    player: AudioStore;
-    settings: TTSPluginSettingsStore;
-    sink: AudioSink;
-    shouldShow: boolean | (() => boolean);
-    isMobilePhone: boolean | (() => boolean);
-    audioElement?: HTMLAudioElement;
-    onOpenSettings: () => void;
-    onPlaySelection: () => void;
-    onSaveDocumentAudio?: () => void;
-  }): React.ReactNode => {
+    canSaveDocumentAudio,
+  }: PlayerViewProps): React.ReactNode => {
     // Evaluate getters inside observer body so MobX tracks dependencies
     const isMobile =
       typeof isMobilePhone === "function" ? isMobilePhone() : isMobilePhone;
@@ -46,76 +59,73 @@ export const PlayerView = observer(
         }),
       [player, settings, onPlaySelection],
     );
+    const exportMenuItems = createExportMenuItems({
+      player,
+      onExportSelectionAudio,
+      canExportSelectionAudio,
+      onSaveDocumentAudio,
+      canSaveDocumentAudio,
+    });
+    const exportInProgress = !!player.exportProgress;
 
-    if (isMobile || !visible) {
+    if (isMobile || (!visible && !exportInProgress)) {
       return null;
     }
     return (
       <div className="tts-toolbar-player">
-        <div className="tts-toolbar-player-button-group">
-          <IconButton
-            icon="play"
-            tooltip="Play selection"
-            onClick={() => actions.playSelection()}
-          />
-          {onSaveDocumentAudio &&
-            (player.exportProgress ? (
+        {visible && (
+          <div className="tts-toolbar-player-button-group">
+            <IconButton
+              icon="play"
+              tooltip="Play selection"
+              onClick={() => actions.playSelection()}
+            />
+          </div>
+        )}
+        {visible && (
+          <div className="tts-toolbar-player-button-group">
+            <IconButton
+              icon="skip-back"
+              tooltip="Previous"
+              onClick={() => actions.previous()}
+              disabled={!player.activeText}
+            />
+
+            {sink.trackStatus === "playing" ? (
               <IconButton
-                icon="square"
-                tooltip={formatExportTooltip(player.exportProgress)}
-                onClick={() => player.cancelExport()}
-                highlight
+                key="pause"
+                icon="pause"
+                tooltip="Pause"
+                onClick={() => actions.playPause()}
               />
             ) : (
               <IconButton
-                icon="download"
-                tooltip="Save document as audio"
-                onClick={() => onSaveDocumentAudio()}
+                key="play"
+                icon="step-forward"
+                tooltip="Resume"
+                onClick={() => actions.playPause()}
+                disabled={!player.activeText}
               />
-            ))}
-        </div>
-        <div className="tts-toolbar-player-button-group">
-          <IconButton
-            icon="skip-back"
-            tooltip="Previous"
-            onClick={() => actions.previous()}
-            disabled={!player.activeText}
-          />
-
-          {sink.trackStatus === "playing" ? (
+            )}
             <IconButton
-              key="pause"
-              icon="pause"
-              tooltip="Pause"
-              onClick={() => actions.playPause()}
-            />
-          ) : (
-            <IconButton
-              key="play"
-              icon="step-forward"
-              tooltip="Resume"
-              onClick={() => actions.playPause()}
+              icon="skip-forward"
+              tooltip="Next"
+              onClick={() => actions.next()}
               disabled={!player.activeText}
             />
-          )}
-          <IconButton
-            icon="skip-forward"
-            tooltip="Next"
-            onClick={() => actions.next()}
-            disabled={!player.activeText}
-          />
-          <IconButton
-            icon={player.autoScrollEnabled ? "eye" : "eye-off"}
-            tooltip={
-              player.autoScrollEnabled
-                ? "Autoscroll enabled (click to disable)"
-                : "Autoscroll disabled (click to enable and scroll to current position)"
-            }
-            onClick={() => actions.toggleAutoscroll()}
-            highlight={player.autoScrollEnabled}
-          />
-          <EditPlaybackSpeedButton settings={settings} />
-        </div>
+            <IconButton
+              icon={player.autoScrollEnabled ? "eye" : "eye-off"}
+              tooltip={
+                player.autoScrollEnabled
+                  ? "Autoscroll enabled (click to disable)"
+                  : "Autoscroll disabled (click to enable and scroll to current position)"
+              }
+              onClick={() => actions.toggleAutoscroll()}
+              highlight={player.autoScrollEnabled}
+            />
+            <EditPlaybackSpeedButton settings={settings} />
+          </div>
+        )}
         <div className="tts-audio-status-container">
           <AudioStatusInfoContents
             audioElement={audioElement}
@@ -125,18 +135,79 @@ export const PlayerView = observer(
           />
         </div>
         <div className="tts-toolbar-player-button-group">
-          {player.activeText && (
+          {player.exportProgress && (
+            <button
+              type="button"
+              className="tts-export-cancel-button"
+              onClick={() => player.cancelExport()}
+              title="Cancel audio export"
+            >
+              Cancel
+            </button>
+          )}
+          {visible && player.activeText && (
             <IconButton
               tooltip="Cancel playback"
               icon="x"
               onClick={() => actions.stop()}
             />
           )}
+          {visible && exportMenuItems.length > 0 && (
+            <ToolbarOverflowMenu items={exportMenuItems} />
+          )}
         </div>
       </div>
     );
   },
 );
+
+function createExportMenuItems({
+  player,
+  onExportSelectionAudio,
+  canExportSelectionAudio,
+  onSaveDocumentAudio,
+  canSaveDocumentAudio,
+}: {
+  player: AudioStore;
+  onExportSelectionAudio?: () => void;
+  canExportSelectionAudio?: Availability;
+  onSaveDocumentAudio?: () => void;
+  canSaveDocumentAudio?: Availability;
+}): ToolbarOverflowMenuItem[] {
+  const items: ToolbarOverflowMenuItem[] = [];
+
+  if (onExportSelectionAudio) {
+    items.push({
+      id: "export-selection-audio",
+      label: "Export selection as audio...",
+      disabled: () =>
+        !!player.exportProgress || !isAvailable(canExportSelectionAudio, true),
+      onSelect: onExportSelectionAudio,
+    });
+  }
+
+  if (onSaveDocumentAudio) {
+    items.push({
+      id: "save-document-audio",
+      label: "Save document as audio...",
+      disabled: () =>
+        !!player.exportProgress || !isAvailable(canSaveDocumentAudio, true),
+      onSelect: onSaveDocumentAudio,
+    });
+  }
+
+  return items;
+}
+
+function isAvailable(
+  value: Availability | undefined,
+  fallback: boolean,
+): boolean {
+  if (value === undefined) {
+    return fallback;
+  }
+  return typeof value === "function" ? value() : value;
+}
 
 const EditPlaybackSpeedButton: React.FC<{
   settings: TTSPluginSettingsStore;
@@ -221,42 +292,27 @@ const EditPlaybackSpeedButton: React.FC<{
   );
 });
 
-function formatExportTooltip(progress: {
-  completed: number;
-  total: number;
-}): string {
-  if (!progress.total) {
-    return "Stop saving audio";
-  }
-  return `Stop saving audio (${progress.completed}/${progress.total} chunks)`;
-}
-
-const ExportProgressBar: React.FC<{
-  progress: { completed: number; total: number };
+const ExportStatus: React.FC<{
+  progress: ExportProgress;
 }> = ({ progress }) => {
-  const pct = progress.total
-    ? Math.round((progress.completed / progress.total) * 100)
-    : 0;
   return (
-    <span
-      className="tts-export-progress"
-      role="progressbar"
-      aria-valuemin={0}
-      aria-valuemax={100}
-      aria-valuenow={pct}
-    >
-      <span className="tts-export-progress-label">
-        Saving audio… {progress.completed}/{progress.total}
-      </span>
-      <span className="tts-export-progress-track">
-        <span
-          className="tts-export-progress-fill"
-          style={{ width: `${pct}%` }}
-        />
-      </span>
+    <span className="tts-export-status" role="status">
+      {formatExportProgressLabel(progress)}
     </span>
   );
 };
+
+function formatExportProgressLabel(progress: ExportProgress): string {
+  if (progress.total <= 1) {
+    return "Saving document audio...";
+  }
+
+  const currentSection =
+    progress.completed >= progress.total
+      ? progress.total
+      : progress.completed + 1;
+  return `Saving document audio... ${currentSection} of ${progress.total}`;
+}
 
 const AudioStatusInfoContents: React.FC<{
   audioElement?: HTMLAudioElement;
@@ -265,7 +321,7 @@ const AudioStatusInfoContents: React.FC<{
   onOpenSettings: () => void;
 }> = observer(({ audioElement, player, settings, onOpenSettings }) => {
   if (player.exportProgress) {
-    return <ExportProgressBar progress={player.exportProgress} />;
+    return <ExportStatus progress={player.exportProgress} />;
   }
   if (settings.apiKeyValid === false) {
     return (

--- a/packages/ui/src/components/TTSSettingsTabComponent.tsx
+++ b/packages/ui/src/components/TTSSettingsTabComponent.tsx
@@ -2,9 +2,12 @@ import { observer } from "mobx-react-lite";
 import * as React from "react";
 import { AudioStore } from "open-tts";
 import {
+  AudioExportDestination,
   ModelProvider,
   PlayerViewMode,
   TTSPluginSettingsStore,
+  audioExportDestinations,
+  isAudioExportDestination,
   isPlayerViewMode,
   modelProviders,
   playViewModes,
@@ -74,6 +77,7 @@ export const TTSSettingsTabComponent: React.FC<{
       <SettingSection title="Storage">
         <CacheDuration store={store} player={player} />
         <AudioFolderComponent store={store} />
+        <AudioExportDestinationComponent store={store} />
       </SettingSection>
 
       <SettingSection title="Audio">
@@ -383,6 +387,52 @@ const CacheDuration: React.FC<{
         </div>
       </div>
     </>
+  );
+});
+
+function describeExportDestination(d: AudioExportDestination): string {
+  switch (d) {
+    case "vault":
+      return "Save to vault folder";
+    case "download":
+      return "Save to system download folder";
+    case "prompt":
+      return "Ask each time";
+  }
+}
+
+const AudioExportDestinationComponent: React.FC<{
+  store: TTSPluginSettingsStore;
+}> = observer(({ store }) => {
+  return (
+    <div className="setting-item">
+      <div className="setting-item-info">
+        <div className="setting-item-name">Document Audio Destination</div>
+        <div className="setting-item-description">
+          Where to save audio generated from the "Save document as audio"
+          toolbar action.
+        </div>
+      </div>
+      <div className="setting-item-control">
+        <select
+          value={store.settings.audioExportDestination}
+          onChange={(e) => {
+            const value = e.target.value;
+            if (isAudioExportDestination(value)) {
+              store.updateSettings({ audioExportDestination: value });
+            } else {
+              console.error("invalid audio export destination", value);
+            }
+          }}
+        >
+          {audioExportDestinations.map((d) => (
+            <option key={d} value={d}>
+              {describeExportDestination(d)}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
   );
 });
 

--- a/packages/ui/src/components/ToolbarOverflowMenu.tsx
+++ b/packages/ui/src/components/ToolbarOverflowMenu.tsx
@@ -1,0 +1,96 @@
+import * as React from "react";
+import { IconButton } from "./IconButton";
+
+export interface ToolbarOverflowMenuItem {
+  id: string;
+  label: string;
+  disabled?: boolean | (() => boolean);
+  onSelect: () => void;
+}
+
+export function ToolbarOverflowMenu({
+  align = "right",
+  items,
+}: {
+  align?: "left" | "right";
+  items: ToolbarOverflowMenuItem[];
+}): React.ReactNode {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const rootRef = React.useRef<HTMLSpanElement | null>(null);
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleClickOutside = (event: MouseEvent): void => {
+      if (rootRef.current?.contains(event.target as Node)) {
+        return;
+      }
+      setIsOpen(false);
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
+
+  return (
+    <span className="tts-toolbar-overflow" ref={rootRef}>
+      <IconButton
+        icon="more-vertical"
+        tooltip="More"
+        onClick={() => setIsOpen((open) => !open)}
+      />
+      {isOpen && (
+        <span
+          className={`menu tts-toolbar-overflow-menu tts-toolbar-overflow-menu-align-${align}`}
+          role="menu"
+        >
+          {items.map((item) => {
+            const disabled = isMenuItemDisabled(item);
+            return (
+              <button
+                type="button"
+                className="menu-item tappable tts-toolbar-overflow-menu-item"
+                disabled={disabled}
+                aria-disabled={disabled}
+                role="menuitem"
+                key={item.id}
+                onClick={() => {
+                  if (disabled) {
+                    return;
+                  }
+                  item.onSelect();
+                  setIsOpen(false);
+                }}
+              >
+                <span className="menu-item-title">{item.label}</span>
+              </button>
+            );
+          })}
+        </span>
+      )}
+    </span>
+  );
+}
+
+function isMenuItemDisabled(item: ToolbarOverflowMenuItem): boolean {
+  return typeof item.disabled === "function"
+    ? item.disabled()
+    : !!item.disabled;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,5 +5,6 @@ export * from "./components/DownloadProgress";
 export * from "./components/EditorActionIcon";
 export * from "./components/IconButton";
 export * from "./components/PlayerView";
+export * from "./components/ToolbarOverflowMenu";
 export * from "./components/TTSSettingsTabComponent";
 export * from "./util/TooltipContext";

--- a/packages/web/src/components/CommandBar.test.tsx
+++ b/packages/web/src/components/CommandBar.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { EditorView } from "@codemirror/view";
+import { AudioStore, TTSPluginSettingsStore } from "open-tts";
+import { WebAudioSink } from "open-tts/browser";
+import { CommandBar } from "./CommandBar";
+import { WebObsidianBridge } from "./WebBridge";
+
+function createEditor(text: string, from: number, to: number): EditorView {
+  return {
+    state: {
+      selection: {
+        main: { from, to, head: to },
+      },
+      doc: {
+        length: text.length,
+        sliceString: (start: number, end: number) => text.slice(start, end),
+        toString: () => text,
+      },
+    },
+  } as unknown as EditorView;
+}
+
+function createSettingsStore(): TTSPluginSettingsStore {
+  return {
+    settings: {
+      showPlayerView: "never",
+      playbackSpeed: 1,
+    },
+    setSpeed: vi.fn(),
+    updateSettings: vi.fn(),
+  } as unknown as TTSPluginSettingsStore;
+}
+
+function createAudioStore(exportRunning = false): AudioStore {
+  return {
+    activeText: null,
+    autoScrollEnabled: true,
+    exportProgress: exportRunning ? { completed: 0, total: 1 } : null,
+    destroy: vi.fn(),
+    cancelExport: vi.fn(),
+  } as unknown as AudioStore;
+}
+
+function createSink(): WebAudioSink {
+  return {
+    trackStatus: "paused",
+  } as unknown as WebAudioSink;
+}
+
+function createBridge(editor: EditorView): WebObsidianBridge {
+  return {
+    activeEditor: editor,
+    focusedEditor: editor,
+    detachedAudio: false,
+    triggerSelection: vi.fn(),
+    playSelection: vi.fn(),
+    playDetached: vi.fn(),
+    onTextChanged: vi.fn(),
+    openSettings: vi.fn(),
+    destroy: vi.fn(),
+    isMobile: vi.fn(() => false),
+    setActiveEditor: vi.fn(),
+    exportAudio: vi.fn(() => Promise.resolve()),
+    saveDocumentAudio: vi.fn(() => Promise.resolve()),
+  };
+}
+
+describe("CommandBar", () => {
+  it("moves export selection behind the overflow menu", () => {
+    const editor = createEditor("Hello world", 0, 5);
+    const obsidian = createBridge(editor);
+
+    render(
+      <CommandBar
+        settingsStore={createSettingsStore()}
+        store={createAudioStore()}
+        sink={createSink()}
+        editor={editor}
+        obsidian={obsidian}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Export Selection to Audio" }),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Export selection as audio..." }),
+    );
+
+    expect(obsidian.exportAudio).toHaveBeenCalledWith("Hello", false);
+  });
+
+  it("disables selection export when there is no selected text", () => {
+    const editor = createEditor("Hello world", 0, 0);
+
+    render(
+      <CommandBar
+        settingsStore={createSettingsStore()}
+        store={createAudioStore()}
+        sink={createSink()}
+        editor={editor}
+        obsidian={createBridge(editor)}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+    expect(
+      (
+        screen.getByRole("menuitem", {
+          name: "Export selection as audio...",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it("disables export actions while an export is running", () => {
+    const editor = createEditor("Hello world", 0, 5);
+
+    render(
+      <CommandBar
+        settingsStore={createSettingsStore()}
+        store={createAudioStore(true)}
+        sink={createSink()}
+        editor={editor}
+        obsidian={createBridge(editor)}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+    expect(
+      (
+        screen.getByRole("menuitem", {
+          name: "Export selection as audio...",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    expect(
+      (
+        screen.getByRole("menuitem", {
+          name: "Save document as audio...",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+});

--- a/packages/web/src/components/CommandBar.tsx
+++ b/packages/web/src/components/CommandBar.tsx
@@ -115,6 +115,11 @@ export const CommandBar: React.FC<{
               audioElement={sink.audioElement}
               onOpenSettings={onOpenSettings}
               onPlaySelection={() => obsidian.playSelection()}
+              onSaveDocumentAudio={() => {
+                obsidian.saveDocumentAudio().catch((ex) => {
+                  console.error("Couldn't save document audio!", ex);
+                });
+              }}
             />
           </div>
         )}

--- a/packages/web/src/components/CommandBar.tsx
+++ b/packages/web/src/components/CommandBar.tsx
@@ -7,7 +7,22 @@ import { TTSPluginSettingsStore } from "open-tts";
 import { WebAudioSink } from "open-tts/browser";
 import { IconButton } from "@open-tts/ui";
 import { PlayerView } from "@open-tts/ui";
+import { ToolbarOverflowMenu } from "@open-tts/ui";
 import { WebObsidianBridge } from "./WebBridge";
+
+function getSelectedText(editor: EditorView | undefined): string {
+  if (!editor) {
+    return "";
+  }
+
+  const state = editor.state;
+  const selection = state.selection.main;
+  if (selection.from === selection.to) {
+    return "";
+  }
+
+  return state.doc.sliceString(selection.from, selection.to);
+}
 
 export const CommandBar: React.FC<{
   settingsStore: TTSPluginSettingsStore;
@@ -49,20 +64,18 @@ export const CommandBar: React.FC<{
     const handleExportSelection = useCallback(() => {
       if (!editor || !obsidian) return;
 
-      const state = editor.state;
-      const selection = state.selection.main;
-      const doc = state.doc;
-
-      // Get selected text or all text if nothing selected
-      const text =
-        selection.from !== selection.to
-          ? doc.sliceString(selection.from, selection.to)
-          : doc.toString();
+      const text = getSelectedText(editor);
 
       if (text.trim()) {
         obsidian.exportAudio(text, false);
       }
     }, [editor, obsidian]);
+
+    const handleSaveDocumentAudio = useCallback(() => {
+      obsidian?.saveDocumentAudio().catch((ex) => {
+        console.error("Couldn't save document audio!", ex);
+      });
+    }, [obsidian]);
 
     const _handleExportFromClipboard = useCallback(async () => {
       if (!obsidian) return;
@@ -94,12 +107,6 @@ export const CommandBar: React.FC<{
           disabled={!editor}
         />
 
-        <IconButton
-          icon="download"
-          tooltip="Export Selection to Audio"
-          onClick={handleExportSelection}
-          disabled={!editor}
-        />
         {/* Separator */}
         <div className="web-tts-command-bar-separator" />
 
@@ -115,14 +122,29 @@ export const CommandBar: React.FC<{
               audioElement={sink.audioElement}
               onOpenSettings={onOpenSettings}
               onPlaySelection={() => obsidian.playSelection()}
-              onSaveDocumentAudio={() => {
-                obsidian.saveDocumentAudio().catch((ex) => {
-                  console.error("Couldn't save document audio!", ex);
-                });
-              }}
             />
           </div>
         )}
+
+        <ToolbarOverflowMenu
+          items={[
+            {
+              id: "export-selection-audio",
+              label: "Export selection as audio...",
+              disabled: () =>
+                !editor ||
+                !getSelectedText(editor).trim() ||
+                !!store.exportProgress,
+              onSelect: handleExportSelection,
+            },
+            {
+              id: "save-document-audio",
+              label: "Save document as audio...",
+              disabled: () => !editor || !obsidian || !!store.exportProgress,
+              onSelect: handleSaveDocumentAudio,
+            },
+          ]}
+        />
       </div>
     );
   },

--- a/packages/web/src/components/WebBridge.ts
+++ b/packages/web/src/components/WebBridge.ts
@@ -87,6 +87,41 @@ export class WebBridgeImpl implements WebObsidianBridge {
     return window.innerWidth <= 768; // Simple mobile detection
   };
 
+  saveDocumentAudio = async () => {
+    if (!this.activeEditor) {
+      alert("Open or focus an editor first.");
+      return;
+    }
+    const text = this.activeEditor.state.doc.toString();
+    if (!text.trim()) {
+      alert("No text in the editor to convert.");
+      return;
+    }
+    try {
+      const audioData = await this.store.exportAudio(text);
+      const hash = this.hashString(text).toString(16).slice(0, 8);
+      this.downloadBlob(audioData, `aloud-document-${hash}.mp3`);
+    } catch (ex) {
+      if (ex instanceof DOMException && ex.name === "AbortError") {
+        return;
+      }
+      console.error("Couldn't save document audio!", ex);
+      alert("Failed to save audio");
+    }
+  };
+
+  private downloadBlob(bytes: ArrayBuffer, filename: string): void {
+    const blob = new Blob([bytes], { type: "audio/mpeg" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
   exportAudio = async (text: string, replaceSelection?: boolean) => {
     if (!text.trim()) {
       alert("No text to export");


### PR DESCRIPTION
## Summary

Adds a one-click way to export the **entire active document** as an audio file from the player toolbar, with a live progress indicator and cancellable generation that aborts in-flight HTTP requests.

Today, audio export only exists via the right-click menu (selection or clipboard) and always inserts an `![[file.mp3]]` embed into the note. This PR adds a toolbar-driven path for the "I just want the audio file" workflow — share it, post it, drop it into a podcast tool — without modifying the document.

## What's new

### 1. Toolbar action + settings (UI)

- New `download` icon in the `PlayerView` toolbar (and equivalent callback wired in the web `CommandBar`). Tooltip: *"Save document as audio"*.
- New **"Document Audio Destination"** setting under the **Storage** section:
  - **Save to vault folder** — same `audioFolder` as the existing export path; just no embed inserted.
  - **Save to system download folder** — generates an MP3 and triggers a browser-style download (Blob URL + anchor click). In Obsidian Desktop this lands in the platform's downloads folder.
  - **Ask each time** — opens a small `Modal` with three buttons (Vault folder / Download / Cancel).
- New **"Save document as audio"** command (palette / hotkey-assignable). The command is hidden while an export is in flight to prevent concurrent runs from racing the same progress observable.

### 2. AudioStore.exportAudio progress + cancellation

- `exportProgress: ExportProgress | null` observable on `AudioStore` reports `{ completed, total }` chunk counts during export. Cleared in `finally`.
- `cancelExport()` aborts at the next chunk boundary and — combined with the signal threading below — also aborts the in-flight `fetch`.
- `PlayerView` observes `exportProgress` and swaps the download button for a stop button while running, plus shows a thin determinate progress strip in the existing status area: *"Saving audio… 3/12"*.

### 3. AbortSignal threaded through `TTSModel.call`

- `TTSModel.call` gained an optional trailing `signal?: AbortSignal` parameter (backward-compatible — existing callers/providers ignore it).
- All nine fetch-based providers (OpenAI, OpenAI-compatible, Hume, ElevenLabs, Azure, MiniMax, Fish, Inworld, Polly) pass it to `fetch()`.
- **Gemini** uses the `@google/genai` SDK which does not currently expose `AbortSignal`, so the call is raced against the signal to free the caller on cancel. The underlying HTTPS request may continue in the background — best we can do without forking the SDK; noted in an inline comment.

## Design notes

- The new export path **reuses** `AudioStore.exportAudio` end-to-end; no new generation pipeline.
- The toolbar export **does not modify the editor** (no `![[file.mp3]]` insertion) — that's the existing `exportAudio` behavior and stays unchanged.
- Filename: `<basename>-<hash>.mp3` (basename sanitized to `[a-zA-Z0-9_-]+`, truncated to 60 chars; falls back to `aloud-document-<hash>` when there's no active file).
- Progress UI is observable-driven, so multiple `PlayerView` instances (e.g. across split panes) all reflect the same export state, and clicking stop in any of them cancels.

## Coordination with #157

PR #157 ("Add setting for exported audio placement") touches three of the same files (`TTSPluginSettings.ts`, `ObsidianBridge.ts`, `TTSSettingsTabComponent.tsx`) but with **orthogonal scope** — it tunes embed placement for the existing right-click export, while this PR adds a separate toolbar action. The overlaps are in distinct sections (different settings, different UI section, different bridge method) and should be trivial to resolve in whichever merges second. Happy to rebase if you'd like a specific merge order.

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` clean
- [x] `pnpm run test` — 353/353 passing. Added new mocks for `Modal` and `Setting` in `__mocks__/obsidian.ts` and the inline mock in `ObsidianBridge.test.ts`. `TTSActions.test.ts` mock-player extended with the two new `AudioStore` members.
- [x] `pnpm run format:check` clean
- [x] `pnpm run obsidian:build` succeeds.
- [x] Manual test in Obsidian Desktop against a multi-chunk markdown document:
  - Progress ticks 1/N → N/N
  - Mid-export stop aborts the in-flight chunk immediately and shows *"Audio export cancelled"*
  - Vault destination writes to `<audioFolder>/<basename>-<hash>.mp3` with no editor mutation
  - Download destination drops the file in the OS downloads folder
  - "Ask each time" modal works and `Esc` / clicking outside cancels cleanly
  - Command palette entry hides while an export is running