### PR TITLE
Insert exported audio below selected line

### DIFF
--- a/packages/obsidian/src/ObsidianBridge.ts
+++ b/packages/obsidian/src/ObsidianBridge.ts
@@ -166,12 +166,30 @@ export class ObsidianBridgeImpl implements ObsidianBridge {
         if (replaceSelection) {
           editor.replaceSelection(loadingReplacement);
         } else {
-          // insert at the start of the selection
-          editor.replaceRange(
-            loadingReplacement,
-            editor.getCursor("from"),
-            editor.getCursor("from"),
-          );
+          // Insert the exported audio on a new line below the selected line
+          const selectionEnd = editor.getCursor("to");
+          const lineBelowSelection = selectionEnd.line + 1;
+
+          if (lineBelowSelection < editor.lineCount()) {
+            const insertPosition = { line: lineBelowSelection, ch: 0 };
+
+            editor.replaceRange(
+              loadingReplacement,
+              insertPosition,
+              insertPosition,
+            );
+          } else {
+            const endOfLine = {
+              line: selectionEnd.line,
+              ch: editor.getLine(selectionEnd.line).length,
+            };
+
+            editor.replaceRange(
+              `\n${loadingReplacement}`,
+              endOfLine,
+              endOfLine,
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

Changes the Obsidian audio export behavior so that exported audio is inserted on a new line below the selected line, instead of being inserted at the beginning of the selection.

## Changes

* Uses the end of the current selection to determine the insertion position.
* Inserts the exported audio at the beginning of the following line when one exists.
* Adds a new line below the selection when exporting from the last line of a note.
* Preserves the existing behavior when replacing a selection directly.

## Testing

* Built the Obsidian plugin locally.
* Tested the generated plugin in Obsidian.
* Confirmed that exported audio is now embedded on a new line below the selected text.

