### PR TITLE
Fix Fish Audio CORS by switching to requestUrl

### DIFF
--- a/packages/open-tts/src/models/fish.test.ts
+++ b/packages/open-tts/src/models/fish.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { requestUrl } from "obsidian";
 import { DEFAULT_SETTINGS } from "../player/TTSPluginSettings";
 import { TTSModelOptions, TTSErrorInfo } from "./tts-model";
 import {
@@ -11,7 +12,9 @@ import {
   validateApiKeyFish,
 } from "./fish";
 
-global.fetch = vi.fn();
+vi.mock("obsidian", () => ({
+  requestUrl: vi.fn(),
+}));
 
 describe("Fish Audio Model", () => {
   beforeEach(() => {
@@ -54,32 +57,28 @@ describe("Fish Audio Model", () => {
     });
 
     it("should validate the API key by listing voices", async () => {
-      vi.mocked(fetch).mockResolvedValue(
-        fishResponse({
-          status: 200,
-          json: { total: 0, items: [] },
-        }) as Response,
+      vi.mocked(requestUrl).mockResolvedValue(
+        fishResponse({ status: 200, json: { total: 0, items: [] } }),
       );
 
       const result = await validateApiKeyFish("valid-key");
 
       expect(result).toBeUndefined();
-      expect(fetch).toHaveBeenCalledWith(
-        `${FISH_API_URL}/model?page_size=50&page_number=1&sort_by=created_at&self=true`,
-        {
-          headers: {
-            Authorization: "Bearer valid-key",
-          },
+      expect(requestUrl).toHaveBeenCalledWith({
+        url: `${FISH_API_URL}/model?page_size=50&page_number=1&sort_by=created_at&self=true`,
+        headers: {
+          Authorization: "Bearer valid-key",
         },
-      );
+        throw: false,
+      });
     });
 
     it("should report invalid API keys", async () => {
-      vi.mocked(fetch).mockResolvedValue(
+      vi.mocked(requestUrl).mockResolvedValue(
         fishResponse({
           status: 401,
           json: { status: 401, message: "Unauthorized" },
-        }) as Response,
+        }),
       );
 
       const result = await validateApiKeyFish("bad-key");
@@ -97,8 +96,8 @@ describe("Fish Audio Model", () => {
 
     it("should make a Fish Audio TTS request and return mp3 audio", async () => {
       const audio = new Uint8Array([1, 2, 3, 4]).buffer;
-      vi.mocked(fetch).mockResolvedValue(
-        fishResponse({ status: 200, arrayBuffer: audio }) as Response,
+      vi.mocked(requestUrl).mockResolvedValue(
+        fishResponse({ status: 200, arrayBuffer: audio }),
       );
 
       const result = await fishCallTextToSpeech(
@@ -108,7 +107,8 @@ describe("Fish Audio Model", () => {
         {},
       );
 
-      expect(fetch).toHaveBeenCalledWith(`${FISH_API_URL}/v1/tts`, {
+      expect(requestUrl).toHaveBeenCalledWith({
+        url: `${FISH_API_URL}/v1/tts`,
         method: "POST",
         headers: {
           Authorization: "Bearer test-api-key",
@@ -122,6 +122,7 @@ describe("Fish Audio Model", () => {
           mp3_bitrate: 128,
           normalize: true,
         }),
+        throw: false,
       });
       expect(new Uint8Array(result.data)).toEqual(new Uint8Array(audio));
       expect(result.format).toBe("mp3");
@@ -129,8 +130,8 @@ describe("Fish Audio Model", () => {
 
     it("should add Fish Audio sentence pause controls", async () => {
       const audio = new Uint8Array([1, 2, 3, 4]).buffer;
-      vi.mocked(fetch).mockResolvedValue(
-        fishResponse({ status: 200, arrayBuffer: audio }) as Response,
+      vi.mocked(requestUrl).mockResolvedValue(
+        fishResponse({ status: 200, arrayBuffer: audio }),
       );
 
       await fishCallTextToSpeech(
@@ -140,8 +141,7 @@ describe("Fish Audio Model", () => {
         {},
       );
 
-      expect(fetch).toHaveBeenCalledWith(
-        `${FISH_API_URL}/v1/tts`,
+      expect(requestUrl).toHaveBeenCalledWith(
         expect.objectContaining({
           body: JSON.stringify({
             text: "Hello world. (break) Next sentence? (break)",
@@ -166,11 +166,11 @@ describe("Fish Audio Model", () => {
     });
 
     it("should map Fish Audio API errors", async () => {
-      vi.mocked(fetch).mockResolvedValue(
+      vi.mocked(requestUrl).mockResolvedValue(
         fishResponse({
           status: 422,
           json: { status: 422, message: "Invalid reference_id" },
-        }) as Response,
+        }),
       );
 
       try {
@@ -212,7 +212,7 @@ describe("Fish Audio Model", () => {
 
   describe("voice helpers", () => {
     it("should list Fish Audio voices", async () => {
-      vi.mocked(fetch).mockResolvedValue(
+      vi.mocked(requestUrl).mockResolvedValue(
         fishResponse({
           status: 200,
           json: {
@@ -227,7 +227,7 @@ describe("Fish Audio Model", () => {
               },
             ],
           },
-        }) as Response,
+        }),
       );
 
       const voices = await listFishVoices("test-key", true);
@@ -244,7 +244,7 @@ describe("Fish Audio Model", () => {
     });
 
     it("should get a Fish Audio voice by ID", async () => {
-      vi.mocked(fetch).mockResolvedValue(
+      vi.mocked(requestUrl).mockResolvedValue(
         fishResponse({
           status: 200,
           json: {
@@ -254,15 +254,17 @@ describe("Fish Audio Model", () => {
             state: "created",
             type: "tts",
           },
-        }) as Response,
+        }),
       );
 
       const voice = await getFishVoice("test-key", "voice-id");
 
-      expect(fetch).toHaveBeenCalledWith(`${FISH_API_URL}/model/voice-id`, {
+      expect(requestUrl).toHaveBeenCalledWith({
+        url: `${FISH_API_URL}/model/voice-id`,
         headers: {
           Authorization: "Bearer test-key",
         },
+        throw: false,
       });
       expect(voice.title).toBe("Calm Mystical Narrator");
     });
@@ -277,10 +279,12 @@ function fishResponse({
   status: number;
   json?: unknown;
   arrayBuffer?: ArrayBuffer;
-}): Partial<Response> {
+}) {
   return {
     status,
-    json: vi.fn().mockResolvedValue(json),
-    arrayBuffer: vi.fn().mockResolvedValue(arrayBuffer),
+    headers: {} as Record<string, string>,
+    text: "",
+    json,
+    arrayBuffer,
   };
 }

--- a/packages/open-tts/src/models/fish.test.ts
+++ b/packages/open-tts/src/models/fish.test.ts
@@ -85,6 +85,14 @@ describe("Fish Audio Model", () => {
 
       expect(result).toBe("Invalid API key");
     });
+
+    it("should report connection failure when the API is unreachable", async () => {
+      vi.mocked(requestUrl).mockRejectedValue(new Error("net::ERR_FAILED"));
+
+      const result = await validateApiKeyFish("any-key");
+
+      expect(result).toBe("Cannot connect to Fish Audio API");
+    });
   });
 
   describe("fishCallTextToSpeech", () => {
@@ -187,6 +195,51 @@ describe("Fish Audio Model", () => {
           httpErrorCode: 422,
         });
       }
+    });
+
+    it("should not call window.fetch for any requests", async () => {
+      // Fish Audio's /v1/tts endpoint returns 401 on CORS preflight, blocking
+      // fetch() in Obsidian's Electron renderer. requestUrl routes through
+      // Obsidian's native layer and bypasses CORS entirely.
+      const fetchSpy = vi.spyOn(global, "fetch");
+      vi.mocked(requestUrl).mockResolvedValue(
+        fishResponse({
+          status: 200,
+          arrayBuffer: new Uint8Array([1, 2, 3]).buffer,
+        }),
+      );
+
+      await fishCallTextToSpeech("Hello world", options, DEFAULT_SETTINGS, {});
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("should proceed normally when an AbortSignal is passed", async () => {
+      // requestUrl does not support AbortSignal; the signal parameter is
+      // accepted for API compatibility but intentionally unused.
+      const audio = new Uint8Array([1, 2, 3]).buffer;
+      vi.mocked(requestUrl).mockResolvedValue(
+        fishResponse({ status: 200, arrayBuffer: audio }),
+      );
+      const controller = new AbortController();
+
+      const result = await fishCallTextToSpeech(
+        "Hello world",
+        options,
+        DEFAULT_SETTINGS,
+        {},
+        controller.signal,
+      );
+
+      expect(new Uint8Array(result.data)).toEqual(new Uint8Array(audio));
+    });
+
+    it("should propagate network errors from requestUrl", async () => {
+      vi.mocked(requestUrl).mockRejectedValue(new Error("net::ERR_FAILED"));
+
+      await expect(
+        fishCallTextToSpeech("Hello world", options, DEFAULT_SETTINGS, {}),
+      ).rejects.toThrow("net::ERR_FAILED");
     });
   });
 

--- a/packages/open-tts/src/models/fish.ts
+++ b/packages/open-tts/src/models/fish.ts
@@ -1,3 +1,4 @@
+import { requestUrl } from "obsidian";
 import type {
   FishSentencePause,
   TTSPluginSettings,
@@ -65,7 +66,7 @@ export async function fishCallTextToSpeech(
   options: TTSModelOptions,
   _settings: TTSPluginSettings,
   _context: AudioTextContext = {},
-  signal?: AbortSignal,
+  _signal?: AbortSignal,
 ): Promise<AudioData> {
   if (!options.voice) {
     throw new TTSErrorInfo("Voice model ID is required for Fish Audio TTS", {
@@ -79,7 +80,8 @@ export async function fishCallTextToSpeech(
   }
   const sentencePause = parseFishSentencePause(options.instructions);
 
-  const response = await fetch(`${FISH_API_URL}/v1/tts`, {
+  const response = await requestUrl({
+    url: `${FISH_API_URL}/v1/tts`,
     method: "POST",
     headers: {
       Authorization: `Bearer ${options.apiKey || ""}`,
@@ -93,12 +95,15 @@ export async function fishCallTextToSpeech(
       mp3_bitrate: 128,
       normalize: sentencePause === "none",
     }),
-    signal,
+    throw: false,
   });
 
-  await validate200Fish(response);
+  await validate200Fish({
+    status: response.status,
+    json: () => Promise.resolve(response.json),
+  });
   return {
-    data: await response.arrayBuffer(),
+    data: response.arrayBuffer,
     format: "mp3",
   };
 }
@@ -155,31 +160,38 @@ export async function listFishVoices(
     params.set("self", "true");
   }
 
-  const response = await fetch(`${FISH_API_URL}/model?${params.toString()}`, {
+  const response = await requestUrl({
+    url: `${FISH_API_URL}/model?${params.toString()}`,
     headers: {
       Authorization: `Bearer ${apiKey}`,
     },
+    throw: false,
   });
 
-  await validate200Fish(response);
-  return parseFishVoiceList(await response.json());
+  await validate200Fish({
+    status: response.status,
+    json: () => Promise.resolve(response.json),
+  });
+  return parseFishVoiceList(response.json);
 }
 
 export async function getFishVoice(
   apiKey: string,
   voiceId: string,
 ): Promise<FishVoice> {
-  const response = await fetch(
-    `${FISH_API_URL}/model/${encodeURIComponent(voiceId)}`,
-    {
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-      },
+  const response = await requestUrl({
+    url: `${FISH_API_URL}/model/${encodeURIComponent(voiceId)}`,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
     },
-  );
+    throw: false,
+  });
 
-  await validate200Fish(response);
-  return parseFishVoice(await response.json());
+  await validate200Fish({
+    status: response.status,
+    json: () => Promise.resolve(response.json),
+  });
+  return parseFishVoice(response.json);
 }
 
 export async function validate200Fish(

--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -6,6 +6,12 @@ const workspaceRoot = path.resolve(__dirname, "../..");
 
 export default defineConfig({
   plugins: [nodePolyfills()],
+  resolve: {
+    alias: {
+      // obsidian is only available in the desktop plugin; use the no-op shim for the web build
+      obsidian: path.resolve(workspaceRoot, "__mocks__/obsidian.ts"),
+    },
+  },
   root: "./src",
   server: {
     host: "127.0.0.1",


### PR DESCRIPTION
## Summary

The Fish Audio provider added in #142 uses the browser `fetch()` API to call `api.fish.audio`. Obsidian Desktop blocks these requests with CORS errors because the Electron renderer enforces same-origin policy, so Fish Audio never works in the desktop app out of the box. Switching to `requestUrl()` routes the calls through the native Electron layer and bypasses CORS entirely — the same approach every other provider in the plugin already uses.

Because `open-tts` is also bundled for the web app, the web build needs `obsidian` aliased to the existing no-op shim so Vite can resolve the import. CORS isn't an issue in web contexts so the shim's no-op `requestUrl` is fine there.

## Changes

* `fish.ts`: replace `fetch()` with `requestUrl({ ..., throw: false })` in `fishCallTextToSpeech`, `listFishVoices`, and `getFishVoice`
* Adapt the `validate200Fish` call sites to wrap the `requestUrl` response into the existing `{ status, json }` shape, keeping the error-handling path unchanged
* `fish.test.ts`: switch from mocking `global.fetch` to mocking `obsidian.requestUrl`; update assertions to match the new call shape and the synchronous `.json` / `.arrayBuffer` properties on `RequestUrlResponse`
* `packages/web/vite.config.js`: add `resolve.alias` mapping `obsidian` → `__mocks__/obsidian.ts` so the web build resolves the new import

## Test Plan

* `pnpm run test`
* `pnpm run lint`
* `pnpm run build`