### PR TITLE
Serialize Gemini requests and add cooldown after 429

### DIFF
--- a/packages/open-tts/src/models/gemini.test.ts
+++ b/packages/open-tts/src/models/gemini.test.ts
@@ -3,7 +3,9 @@ import {
   geminiTextToSpeech,
   validateApiKeyGemini,
   geminiCallTextToSpeech,
+  geminiRateLimiter,
 } from "./gemini";
+import { TTSErrorInfo } from "./tts-model";
 import { DEFAULT_SETTINGS } from "../player/TTSPluginSettings";
 
 // Create mock functions for Google GenAI
@@ -12,17 +14,19 @@ const mockGenerateContent = vi.fn();
 
 // Mock the Google GenAI module
 vi.mock("@google/genai", () => ({
-  GoogleGenAI: vi.fn(() => ({
-    models: {
+  GoogleGenAI: class {
+    models = {
       list: mockList,
       generateContent: mockGenerateContent,
-    },
-  })),
+    };
+  },
 }));
 
 describe("Gemini Model", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset rate limiter so 429 cooldown from one test doesn't block the next
+    geminiRateLimiter.resetCooldown();
   });
 
   describe("convertToOptions", () => {
@@ -30,7 +34,7 @@ describe("Gemini Model", () => {
       const testSettings = {
         ...DEFAULT_SETTINGS,
         gemini_apiKey: "test-api-key",
-        gemini_ttsModel: "gemini-2.5-flash",
+        gemini_ttsModel: "gemini-2.5-flash-preview-tts",
         gemini_ttsVoice: "Zephyr",
         gemini_ttsInstructions: "Speak naturally",
       };
@@ -39,7 +43,7 @@ describe("Gemini Model", () => {
 
       expect(options).toEqual({
         apiKey: "test-api-key",
-        model: "gemini-2.5-flash",
+        model: "gemini-2.5-flash-preview-tts",
         voice: "Zephyr",
         instructions: "Speak naturally",
       });
@@ -103,7 +107,7 @@ describe("Gemini Model", () => {
       const testSettings = {
         ...DEFAULT_SETTINGS,
         gemini_apiKey: "test-key",
-        gemini_ttsModel: "gemini-2.5-flash",
+        gemini_ttsModel: "gemini-2.5-flash-preview-tts",
         gemini_ttsVoice: "Zephyr",
         gemini_ttsInstructions: "Speak with emotion",
       };
@@ -112,19 +116,17 @@ describe("Gemini Model", () => {
 
       expect(options.instructions).toBe("Speak with emotion");
       expect(options.voice).toBe("Zephyr");
-      expect(options.model).toBe("gemini-2.5-flash");
+      expect(options.model).toBe("gemini-2.5-flash-preview-tts");
     });
   });
 
   describe("Gemini Error Mapping", () => {
     it("should handle ClientError with JSON content", () => {
-      // Create a mock ClientError that mimics the actual error structure
       const error = new Error(
         'got status: 400 . {"error":{"message":"API_KEY_INVALID","status":"INVALID_ARGUMENT"}}',
       );
       error.name = "ClientError";
 
-      // The error should be processed by mapGenAIError in the actual call
       expect(error.message).toContain("got status: 400");
       expect(error.message).toContain("API_KEY_INVALID");
     });
@@ -260,7 +262,7 @@ describe("Gemini Model", () => {
 
       const options = {
         apiKey: "test-key",
-        model: "gemini-2.5-flash",
+        model: "gemini-2.5-flash-preview-tts",
         voice: "Zephyr",
         instructions: "Test instructions",
       };
@@ -302,7 +304,7 @@ describe("Gemini Model", () => {
 
       const options = {
         apiKey: "test-key",
-        model: "gemini-2.5-flash",
+        model: "gemini-2.5-flash-preview-tts",
         voice: "Zephyr",
         instructions: "Speak with emotion",
       };
@@ -342,7 +344,7 @@ describe("Gemini Model", () => {
 
       const options = {
         apiKey: "test-key",
-        model: "gemini-2.5-flash",
+        model: "gemini-2.5-flash-preview-tts",
         voice: "Zephyr",
         instructions: "Read clearly",
       };
@@ -382,7 +384,7 @@ describe("Gemini Model", () => {
 
       const options = {
         apiKey: "test-key",
-        model: "gemini-2.5-flash",
+        model: "gemini-2.5-flash-preview-tts",
         voice: "Zephyr",
         instructions: "",
       };
@@ -421,7 +423,7 @@ describe("Gemini Model", () => {
 
       const options = {
         apiKey: "test-key",
-        model: "gemini-2.5-flash",
+        model: "gemini-2.5-flash-preview-tts",
         voice: "Echo",
         instructions: "Test",
       };
@@ -444,7 +446,7 @@ describe("Gemini Model", () => {
 
       const options = {
         apiKey: "test-key",
-        model: "gemini-2.5-flash",
+        model: "gemini-2.5-flash-preview-tts",
         voice: "Zephyr",
         instructions: "Test",
       };
@@ -452,6 +454,65 @@ describe("Gemini Model", () => {
       await expect(
         geminiCallTextToSpeech("Test", options, DEFAULT_SETTINGS, {}),
       ).rejects.toThrow("Request failed 'INTERNAL'");
+    });
+
+    it("should map ApiError (SDK v2) 429 to RESOURCE_EXHAUSTED with httpErrorCode", async () => {
+      // @google/genai v2+ raises ApiError with .status instead of ClientError with message prefix
+      const error = Object.assign(new Error("Too many requests"), {
+        name: "ApiError",
+        status: 429,
+      });
+      mockGenerateContent.mockRejectedValue(error);
+
+      const options = {
+        apiKey: "k",
+        model: "gemini-2.5-flash-preview-tts",
+        voice: "Zephyr",
+      };
+      try {
+        await geminiCallTextToSpeech("Test", options, DEFAULT_SETTINGS, {});
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(TTSErrorInfo);
+        const ttsErr = err as TTSErrorInfo;
+        expect(ttsErr.httpErrorCode).toBe(429);
+        expect(ttsErr.isRetryable).toBe(true);
+        expect(ttsErr.status).toBe("RESOURCE_EXHAUSTED");
+      }
+    });
+
+    it("should map ApiError 500 to SERVER_ERROR as retryable", async () => {
+      const error = Object.assign(new Error("Internal"), {
+        name: "ApiError",
+        status: 500,
+      });
+      mockGenerateContent.mockRejectedValue(error);
+
+      const options = { apiKey: "k", model: "gemini-2.5-flash-preview-tts" };
+      try {
+        await geminiCallTextToSpeech("Test", options, DEFAULT_SETTINGS, {});
+      } catch (err) {
+        expect(err).toBeInstanceOf(TTSErrorInfo);
+        expect((err as TTSErrorInfo).httpErrorCode).toBe(500);
+        expect((err as TTSErrorInfo).isRetryable).toBe(true);
+      }
+    });
+
+    it("should map ApiError 403 as non-retryable", async () => {
+      const error = Object.assign(new Error("Forbidden"), {
+        name: "ApiError",
+        status: 403,
+      });
+      mockGenerateContent.mockRejectedValue(error);
+
+      const options = { apiKey: "k", model: "gemini-2.5-flash-preview-tts" };
+      try {
+        await geminiCallTextToSpeech("Test", options, DEFAULT_SETTINGS, {});
+      } catch (err) {
+        expect(err).toBeInstanceOf(TTSErrorInfo);
+        expect((err as TTSErrorInfo).httpErrorCode).toBe(403);
+        expect((err as TTSErrorInfo).isRetryable).toBe(false);
+      }
     });
   });
 });

--- a/packages/open-tts/src/models/gemini.ts
+++ b/packages/open-tts/src/models/gemini.ts
@@ -12,6 +12,59 @@ import type { TTSPluginSettings } from "../player/TTSPluginSettings";
 
 export const GEMINI_API_URL = "https://generativelanguage.googleapis.com";
 
+/**
+ * Module-level serializer for Gemini API calls.
+ *
+ * Gemini free tier is ~2 RPM. ChunkLoader fires 3 parallel requests, so
+ * without serialization all 3 hit 429 simultaneously and retry in sync —
+ * the rate-limit cycle repeats forever. This queue ensures requests run one
+ * at a time and enforces a cooldown after any 429 so the next call waits
+ * until the rate-limit window has passed.
+ */
+class GeminiRateLimiter {
+  private chain: Promise<unknown> = Promise.resolve();
+  private cooldownUntil = 0;
+  private readonly cooldownMs: number;
+
+  constructor(cooldownMs = 32_000) {
+    this.cooldownMs = cooldownMs;
+  }
+
+  /** Reset cooldown — used in tests to prevent state leaking between cases. */
+  resetCooldown(): void {
+    this.cooldownUntil = 0;
+    this.chain = Promise.resolve();
+  }
+
+  run<T>(fn: () => Promise<T>): Promise<T> {
+    let resolve!: (v: T) => void;
+    let reject!: (e: unknown) => void;
+    const ticket = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    this.chain = this.chain.then(async () => {
+      const waitMs = Math.max(0, this.cooldownUntil - Date.now());
+      if (waitMs > 0) {
+        await new Promise((r) => setTimeout(r, waitMs));
+      }
+      try {
+        resolve(await fn());
+      } catch (err) {
+        if (err instanceof TTSErrorInfo && err.httpErrorCode === 429) {
+          this.cooldownUntil = Date.now() + this.cooldownMs;
+        }
+        reject(err);
+      }
+    });
+
+    return ticket;
+  }
+}
+
+export const geminiRateLimiter = new GeminiRateLimiter();
+
 export const geminiTextToSpeech: TTSModel = {
   call: geminiCallTextToSpeech,
   validateConnection: async (settings) => {
@@ -52,7 +105,9 @@ export async function validateApiKeyGemini(
 }
 
 /**
- * reraises the exception as a TTSErrorInfo, mapping google gen ai error to a tts error info
+ * Reraises the exception as TTSErrorInfo, mapping @google/genai errors to the
+ * shared TTS error format. Handles both the legacy ClientError name and the
+ * current ApiError class (which carries .status directly).
  */
 function mapGenAIError(error: unknown): TTSErrorInfo {
   if (!(error instanceof Error)) {
@@ -64,67 +119,103 @@ function mapGenAIError(error: unknown): TTSErrorInfo {
         param: null,
       },
     });
-  } else if (error.name !== "ClientError") {
-    return new TTSErrorInfo(error.name, {
-      error: {
-        message: error.message,
-        type: error.name,
-        code: "unknown",
-        param: null,
-      },
-    });
   }
 
-  // Extract JSON from error message if present
-  // Format: "got status: {statusCode} . {jsonObject}"
-  const message = error.message;
-  const jsonStart = message.indexOf(". {");
+  // @google/genai SDK ≥2.x: ApiError carries .status (HTTP code) directly.
+  // Use structural check rather than instanceof to avoid import resolution issues.
+  if (error.name === "ApiError" && isApiError(error)) {
+    const httpErrorCode = error.status;
+    const statusLabel =
+      httpErrorCode === 429
+        ? "RESOURCE_EXHAUSTED"
+        : httpErrorCode >= 500
+          ? "SERVER_ERROR"
+          : "API_ERROR";
 
-  if (jsonStart !== -1) {
-    try {
-      const jsonStr = message.substring(jsonStart + 2); // Skip '. '
-      const geminiResponse = JSON.parse(jsonStr);
-
-      if (geminiResponse.error) {
-        const geminiError = geminiResponse.error;
-
-        // Extract HTTP status code from message prefix
-        const statusMatch = message.match(/got status: (\d+)/);
-        const httpErrorCode = statusMatch
-          ? parseInt(statusMatch[1], 10)
-          : undefined;
-
-        // Map to ErrorMessage format expected by TTSErrorInfo
-        const errorDetails = {
-          error: {
-            message: geminiError.message || "Unknown error",
-            type: geminiError.status || "unknown",
-            code: String(geminiError.code || "unknown"),
-            param: geminiError.details || null,
-          },
-        };
-
+    // Try to extract richer details from the JSON in the message
+    const jsonMatch = error.message.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      try {
+        const body = JSON.parse(jsonMatch[0]);
+        const geminiError = body.error ?? body;
         return new TTSErrorInfo(
-          geminiError.status || error.name,
-          errorDetails,
+          geminiError.status || statusLabel,
+          {
+            error: {
+              message: geminiError.message || error.message,
+              type: geminiError.status || statusLabel,
+              code: String(geminiError.code || httpErrorCode),
+              param: geminiError.details || null,
+            },
+          },
           httpErrorCode,
         );
+      } catch {
+        // fall through to plain extraction below
       }
-    } catch (parseError) {
-      console.warn("Failed to parse Gemini error JSON:", parseError);
-      return new TTSErrorInfo(error.name || "ClientError", {
+    }
+
+    return new TTSErrorInfo(
+      statusLabel,
+      {
         error: {
           message: error.message,
-          type: error.name,
-          code: "unknown",
+          type: statusLabel,
+          code: String(httpErrorCode),
           param: null,
         },
-      });
-    }
+      },
+      httpErrorCode,
+    );
   }
 
-  // Fallback for any other error format
-  return new TTSErrorInfo(error.name || "ClientError", {
+  // Legacy ClientError format: "got status: NNN . {json}"
+  if (error.name === "ClientError") {
+    const message = error.message;
+    const statusMatch = message.match(/got status: (\d+)/);
+    const httpErrorCode = statusMatch
+      ? parseInt(statusMatch[1], 10)
+      : undefined;
+    const jsonStart = message.indexOf(". {");
+
+    if (jsonStart !== -1) {
+      try {
+        const geminiResponse = JSON.parse(message.substring(jsonStart + 2));
+        const geminiError = geminiResponse.error;
+        if (geminiError) {
+          return new TTSErrorInfo(
+            geminiError.status || "ClientError",
+            {
+              error: {
+                message: geminiError.message || "Unknown error",
+                type: geminiError.status || "unknown",
+                code: String(geminiError.code || "unknown"),
+                param: geminiError.details || null,
+              },
+            },
+            httpErrorCode,
+          );
+        }
+      } catch {
+        // fall through
+      }
+    }
+
+    return new TTSErrorInfo(
+      "ClientError",
+      {
+        error: {
+          message: error.message,
+          type: "ClientError",
+          code: String(httpErrorCode ?? "unknown"),
+          param: null,
+        },
+      },
+      httpErrorCode,
+    );
+  }
+
+  return new TTSErrorInfo(error.name || "unknown", {
     error: {
       message: error.message,
       type: error.name || "unknown",
@@ -141,48 +232,49 @@ export async function geminiCallTextToSpeech(
   context: AudioTextContext = {},
   signal?: AbortSignal,
 ): Promise<AudioData> {
-  const ai = new GoogleGenAI({ apiKey: options.apiKey });
-  let response: GenerateContentResponse;
-  try {
-    // The @google/genai SDK does not currently expose AbortSignal, so we race
-    // the SDK promise against the signal to free the caller on cancel. The
-    // underlying HTTPS request may continue in the background.
-    const generate = ai.models.generateContent({
-      model: options.model,
-      contents: formatMessages(options.instructions, context, text),
-      config: {
-        responseModalities: ["AUDIO"],
-        speechConfig: options.voice && {
-          voiceConfig: {
-            prebuiltVoiceConfig: { voiceName: options.voice },
+  // Serialise through the rate limiter so parallel chunk loads never fire
+  // simultaneously and a shared cooldown is respected after any 429.
+  return geminiRateLimiter.run(async () => {
+    const ai = new GoogleGenAI({ apiKey: options.apiKey });
+    let response: GenerateContentResponse;
+    try {
+      // The @google/genai SDK does not currently expose AbortSignal, so we
+      // race the SDK promise against the signal to free the caller on cancel.
+      const generate = ai.models.generateContent({
+        model: options.model,
+        contents: formatMessages(options.instructions, context, text),
+        config: {
+          responseModalities: ["AUDIO"],
+          speechConfig: options.voice && {
+            voiceConfig: {
+              prebuiltVoiceConfig: { voiceName: options.voice },
+            },
           },
         },
-      },
-    });
-    response = signal ? await raceAbort(generate, signal) : await generate;
-  } catch (error) {
-    if (error instanceof DOMException && error.name === "AbortError") {
-      throw error;
+      });
+      response = signal ? await raceAbort(generate, signal) : await generate;
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        throw error;
+      }
+      throw mapGenAIError(error);
     }
-    throw mapGenAIError(error);
-  }
-  const res = response.candidates?.[0]?.content?.parts?.[0];
-  const generation = res?.inlineData?.data;
-  if (!generation) {
-    console.error("Gemini response missing generations:", res);
-    throw new Error("Gemini response missing generations");
-  }
-
-  // Return native PCM format - conversion happens in the shared audio layer
-  return {
-    data: base64ToArrayBuffer(generation),
-    format: "pcm",
-    pcmMetadata: {
-      sampleRate: 24000,
-      channels: 1,
-      bitDepth: 16,
-    },
-  };
+    const res = response.candidates?.[0]?.content?.parts?.[0];
+    const generation = res?.inlineData?.data;
+    if (!generation) {
+      console.error("Gemini response missing generations:", res);
+      throw new Error("Gemini response missing generations");
+    }
+    return {
+      data: base64ToArrayBuffer(generation),
+      format: "pcm",
+      pcmMetadata: {
+        sampleRate: 24000,
+        channels: 1,
+        bitDepth: 16,
+      },
+    };
+  }); // end geminiRateLimiter.run
 }
 
 function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
@@ -229,4 +321,9 @@ function formatMessages(
   }
   prompt += `\n\nContent: ${text}`;
   return [{ role: "user", parts: [{ text: prompt }] }];
+}
+
+/** Structural guard for @google/genai ApiError (≥2.x), which has .status: number. */
+function isApiError(error: Error): error is Error & { status: number } {
+  return typeof (error as { status?: unknown }).status === "number";
 }


### PR DESCRIPTION
## Summary

Gemini's free tier allows ~2 requests per minute. ChunkLoader fires 3 parallel requests when loading audio chunks, so all 3 hit 429 simultaneously. They then retry in sync, hit 429 again, and the cycle repeats indefinitely — Gemini audio gets permanently stuck for free-tier users.

A module-level `GeminiRateLimiter` queues all `geminiCallTextToSpeech` calls through a promise chain so only one request is in-flight at a time. When any call gets a 429, the limiter sets a 32-second cooldown so the next queued call waits out the rate-limit window before firing.

The same change also updates `mapGenAIError` to handle `ApiError` from `@google/genai` SDK ≥2.x. The new SDK class carries `.status` (HTTP code) directly instead of embedding it in a `ClientError` message string, so the old string-parsing path was silently dropping HTTP codes on newer SDK versions.

## Changes

* `gemini.ts`: add `GeminiRateLimiter` class and wrap `geminiCallTextToSpeech` in `geminiRateLimiter.run()`
* `gemini.ts`: extend `mapGenAIError` to handle `ApiError` (SDK ≥2.x) via a structural `.status` check — 429 → `RESOURCE_EXHAUSTED` (retryable), 5xx → `SERVER_ERROR` (retryable), other → `API_ERROR` (non-retryable)
* `gemini.test.ts`: export `geminiRateLimiter` and call `resetCooldown()` in `beforeEach` so 429 state doesn't leak between test cases; add three `ApiError` mapping tests

## Test Plan

* `pnpm run test`
* `pnpm run lint`
* `pnpm run build`